### PR TITLE
Flush all traces when debug.set(local|upvalue) are used, as they might mutate upvalues which have PROTO_UV_IMMUTABLE set.

### DIFF
--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -1018,6 +1018,10 @@ LUA_API const char *lua_setupvalue(lua_State *L, int idx, int n)
   api_checknelems(L, 1);
   name = lj_debug_uvnamev(f, (uint32_t)(n-1), &val);
   if (name) {
+    /* Flush cache, as the upvalue might have PROTO_UV_IMMUTABLE set, which
+       doesn't take the debug library into account. But not during __gc. */
+    if (lj_trace_flushall(L))
+      lj_err_caller(L, LJ_ERR_NOGCMM);
     L->top--;
     copyTV(L, val, L->top);
     lj_gc_barrier(L, funcV(f), L->top);


### PR DESCRIPTION
As outlined at http://www.freelists.org/post/luajit/Violating-upvalue-immutability-via-the-debug-library, `debug.setlocal` and `debug.setupvalue` can change the value of any upvalue, including those with the `PROTO_UV_IMMUTABLE` flag set, leading to incorrect behaviour at runtime. This incorrect behaviour can be fixed by flushing all traces whenever `debug.set(local|upvalue)` are used (which is a high cost, but the debug library isn't known for its speed, and `debug.setmetatable` can already trigger a full trace flush). The test cases from said mailing-list post are:

``` lua
local C = "x"
local function c() return C end

for i = 1, 2 do
  for j = 1, 60 do
    assert(C == c())
  end
  debug.setupvalue(c, 1, "y")
end
```

``` lua
local C = "x"
local function c() return C end

for i = 1, 2 do
  for j = 1, 60 do
    assert(C == c())
  end
  debug.setlocal(1, 1, "y")
end
```

As well as making `debug.setlocal` and `debug.setupvalue` more expensive, this change also makes it an error to call them from within a `__gc` metamethod. One might reasonably ask why `lj_trace_flushall` refuses to operate when a `__gc` metamethod is running. In the distant past, `__gc` metamethods could be called on-trace, at which point it would be disastrous to free the mcode of a currently executing trace. However, it seems that `__gc` metamethods are no longer called on-trace, so I can't immediately see a reason why `lj_trace_flushall` still has reservations about `__gc` - perhaps it shouldn't?

As matters of procedure, two things arise:
1. How does reviewing of LuaJIT PRs work?
2. Where do new test cases go? (Do PRs with them go on ice until the existing test suite is in a state to be expanded?)
