### PR TITLE
Add compressed bytecode support – only LZF so far.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -108,6 +108,10 @@ XCFLAGS=
 #XCFLAGS+= -DLUAJIT_NUMMODE=1
 #XCFLAGS+= -DLUAJIT_NUMMODE=2
 #
+# Disable LZF-compressed bytecode.  LZF is a very small library and
+# saves more space than it uses even with small files, so it is
+# enabled by default.
+#XCFLAGS+= -DLUAJIT_DISABLE_COMPRESS
 ##############################################################################
 
 ##############################################################################
@@ -165,6 +169,9 @@ XCFLAGS=
 ASOPTIONS= $(CCOPT) $(CCWARN) $(XCFLAGS) $(CFLAGS)
 CCOPTIONS= $(CCDEBUG) $(ASOPTIONS)
 LDOPTIONS= $(CCDEBUG) $(LDFLAGS)
+ifeq (,$(findstring -DLUAJIT_DISABLE_COMPRESS ,$(XCFLAGS)))
+  LDOPTIONS+= -llzf
+endif
 
 HOST_CC= $(CC)
 HOST_RM= rm -f

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -124,9 +124,10 @@ LJLIB_CF(string_dump)
 {
   GCfunc *fn = lj_lib_checkfunc(L, 1);
   int strip = L->base+1 < L->top && tvistruecond(L->base+1);
+  int compress = L->base+2 < L->top && tvistruecond(L->base+2);
   SBuf *sb = lj_buf_tmp_(L);  /* Assumes lj_bcwrite() doesn't use tmpbuf. */
   L->top = L->base+1;
-  if (!isluafunc(fn) || lj_bcwrite(L, funcproto(fn), writer_buf, sb, strip))
+  if (!isluafunc(fn) || lj_bcwrite(L, funcproto(fn), writer_buf, sb, strip, compress))
     lj_err_caller(L, LJ_ERR_STRDUMP);
   setstrV(L, L->top-1, lj_buf_str(L, sb));
   lj_gc_check(L);

--- a/src/lj.supp
+++ b/src/lj.supp
@@ -12,6 +12,21 @@
 {
    Optimized string compare
    Memcheck:Addr4
+   fun:str_fastcmp
+}
+{
+   Optimized string compare
+   Memcheck:Addr1
+   fun:str_fastcmp
+}
+{
+   Optimized string compare
+   Memcheck:Cond
+   fun:str_fastcmp
+}
+{
+   Optimized string compare
+   Memcheck:Addr4
    fun:lj_str_new
 }
 {

--- a/src/lj_bcdump.h
+++ b/src/lj_bcdump.h
@@ -43,8 +43,9 @@
 #define BCDUMP_F_STRIP		0x02
 #define BCDUMP_F_FFI		0x04
 #define BCDUMP_F_FR2		0x08
+#define BCDUMP_F_COMPRESS	0x10
 
-#define BCDUMP_F_KNOWN		(BCDUMP_F_FR2*2-1)
+#define BCDUMP_F_KNOWN		(BCDUMP_F_COMPRESS*2-1)
 
 /* Type codes for the GC constants of a prototype. Plus length for strings. */
 enum {
@@ -52,6 +53,12 @@ enum {
   BCDUMP_KGC_COMPLEX, BCDUMP_KGC_STR
 };
 
+/* Available compression algorithms.  Currently only LZF is supported */
+typedef enum {
+  BCDUMP_COMPRESS_MEMCPY,	/* Not really compression */
+  BCDUMP_COMPRESS_LZF		/* LZF compression */
+} compression_algorithms;
+ 
 /* Type codes for the keys/values of a constant table. */
 enum {
   BCDUMP_KTAB_NIL, BCDUMP_KTAB_FALSE, BCDUMP_KTAB_TRUE,
@@ -61,7 +68,7 @@ enum {
 /* -- Bytecode reader/writer ---------------------------------------------- */
 
 LJ_FUNC int lj_bcwrite(lua_State *L, GCproto *pt, lua_Writer writer,
-		       void *data, int strip);
+		       void *data, int strip, compression_algorithms compress);
 LJ_FUNC GCproto *lj_bcread_proto(LexState *ls);
 LJ_FUNC GCproto *lj_bcread(LexState *ls);
 

--- a/src/lj_bcread.c
+++ b/src/lj_bcread.c
@@ -390,14 +390,7 @@ GCproto *lj_bcread_proto(LexState *ls)
 
 #ifndef LUAJIT_DISABLE_COMPRESS
 typedef MSize (*lj_decompressor)(char const *src, MSize srclen, char *dst, MSize dstlen);
-#if 0
-static char const *null_reader(lua_State *_ignored1, void *_ignored2, size_t *size)
-{
-  (void)_ignored1;
-  (void)_ignored2;
-  return (char const *)(*size = 0);
-}
-#endif
+
 static LJ_AINLINE unsigned int lj_lzf_decompress(char const *src, MSize srclen, char *dst, MSize dstlen)
 {
   lua_assert(srclen <= UINT_MAX);

--- a/src/lj_lex.c
+++ b/src/lj_lex.c
@@ -376,6 +376,8 @@ int lj_lex_setup(lua_State *L, LexState *ls)
   ls->bcstack = NULL;
   ls->sizebcstack = 0;
   ls->tok = 0;
+  ls->tempbuf = NULL;
+  ls->sizetempbuf = 0;
   ls->lookahead = TK_eof;  /* No look-ahead token. */
   ls->linenumber = 1;
   ls->lastline = 1;
@@ -416,6 +418,7 @@ void lj_lex_cleanup(lua_State *L, LexState *ls)
   global_State *g = G(L);
   lj_mem_freevec(g, ls->bcstack, ls->sizebcstack, BCInsLine);
   lj_mem_freevec(g, ls->vstack, ls->sizevstack, VarInfo);
+  if (ls->tempbuf) lj_mem_free(g, ls->tempbuf, ls->sizetempbuf);
   lj_buf_free(g, &ls->sb);
 }
 
@@ -479,4 +482,3 @@ void lj_lex_init(lua_State *L)
     s->reserved = (uint8_t)(i+1);
   }
 }
-

--- a/src/lj_lex.h
+++ b/src/lj_lex.h
@@ -72,6 +72,8 @@ typedef struct LexState {
   MSize vtop;		/* Top of variable stack. */
   BCInsLine *bcstack;	/* Stack for bytecode instructions/line numbers. */
   MSize sizebcstack;	/* Size of bytecode stack. */
+  char *tempbuf;	/* Temporary buffer for decompression */
+  MSize sizetempbuf;	/* Size of temporary buffer */
   uint32_t level;	/* Syntactical nesting level. */
 } LexState;
 
@@ -82,5 +84,4 @@ LJ_FUNC LexToken lj_lex_lookahead(LexState *ls);
 LJ_FUNC const char *lj_lex_token2str(LexState *ls, LexToken tok);
 LJ_FUNC_NORET void lj_lex_error(LexState *ls, LexToken tok, ErrMsg em, ...);
 LJ_FUNC void lj_lex_init(lua_State *L);
-
 #endif

--- a/src/lj_load.c
+++ b/src/lj_load.c
@@ -161,7 +161,7 @@ LUA_API int lua_dump(lua_State *L, lua_Writer writer, void *data)
   cTValue *o = L->top-1;
   api_check(L, L->top > L->base);
   if (tvisfunc(o) && isluafunc(funcV(o)))
-    return lj_bcwrite(L, funcproto(funcV(o)), writer, data, 0);
+    return lj_bcwrite(L, funcproto(funcV(o)), writer, data, 0, BCDUMP_COMPRESS_LZF);
   else
     return 1;
 }


### PR DESCRIPTION
This adds support for bytecode compression using the LZF compression library.

Fixes #60.