### PR TITLE
snap_sunk_store2 must use IR from the given trace not from the J->cur.

### DIFF
--- a/src/lj_snap.c
+++ b/src/lj_snap.c
@@ -26,9 +26,6 @@
 #include "lj_cdata.h"
 #endif
 
-/* Some local macros to save typing. Undef'd at the end. */
-#define IR(ref)		(&J->cur.ir[(ref)])
-
 /* Pass IR on to next optimization in chain (FOLD). */
 #define emitir(ot, a, b)	(lj_ir_set(J, (ot), (a), (b)), lj_opt_fold(J))
 
@@ -73,7 +70,7 @@ static MSize snapshot_slots(jit_State *J, SnapEntry *map, BCReg nslots)
     IRRef ref = tref_ref(tr);
     if (ref) {
       SnapEntry sn = SNAP_TR(s, tr);
-      IRIns *ir = IR(ref);
+      IRIns *ir = &J->cur.ir[ref];
       if (!(sn & (SNAP_CONT|SNAP_FRAME)) &&
 	  ir->o == IR_SLOAD && ir->op1 == s && ref > retf) {
 	/* No need to snapshot unmodified non-inherited slots. */
@@ -407,24 +404,24 @@ static TRef snap_pref(jit_State *J, GCtrace *T, SnapEntry *map, MSize nmax,
 }
 
 /* Check whether a sunk store corresponds to an allocation. Slow path. */
-static int snap_sunk_store2(jit_State *J, IRIns *ira, IRIns *irs)
+static int snap_sunk_store2(GCtrace *T, IRIns *ira, IRIns *irs)
 {
   if (irs->o == IR_ASTORE || irs->o == IR_HSTORE ||
       irs->o == IR_FSTORE || irs->o == IR_XSTORE) {
-    IRIns *irk = IR(irs->op1);
+    IRIns *irk = &T->ir[irs->op1];
     if (irk->o == IR_AREF || irk->o == IR_HREFK)
-      irk = IR(irk->op1);
-    return (IR(irk->op1) == ira);
+      irk = &T->ir[irk->op1];
+    return (&T->ir[irk->op1] == ira);
   }
   return 0;
 }
 
 /* Check whether a sunk store corresponds to an allocation. Fast path. */
-static LJ_AINLINE int snap_sunk_store(jit_State *J, IRIns *ira, IRIns *irs)
+static LJ_AINLINE int snap_sunk_store(GCtrace *T, IRIns *ira, IRIns *irs)
 {
   if (irs->s != 255)
     return (ira + irs->s == irs);  /* Fast check. */
-  return snap_sunk_store2(J, ira, irs);
+  return snap_sunk_store2(T, ira, irs);
 }
 
 /* Replay snapshot state to setup side trace. */
@@ -487,7 +484,7 @@ void lj_snap_replay(jit_State *J, GCtrace *T)
 	} else {
 	  IRIns *irs;
 	  for (irs = ir+1; irs < irlast; irs++)
-	    if (irs->r == RID_SINK && snap_sunk_store(J, ir, irs)) {
+	    if (irs->r == RID_SINK && snap_sunk_store(T, ir, irs)) {
 	      if (snap_pref(J, T, map, nent, seen, irs->op2) == 0)
 		snap_pref(J, T, map, nent, seen, T->ir[irs->op2].op1);
 	      else if ((LJ_SOFTFP || (LJ_32 && LJ_HASFFI)) &&
@@ -527,7 +524,7 @@ void lj_snap_replay(jit_State *J, GCtrace *T)
 	  TRef tr = emitir(ir->ot, op1, op2);
 	  J->slot[snap_slot(sn)] = tr;
 	  for (irs = ir+1; irs < irlast; irs++)
-	    if (irs->r == RID_SINK && snap_sunk_store(J, ir, irs)) {
+	    if (irs->r == RID_SINK && snap_sunk_store(T, ir, irs)) {
 	      IRIns *irr = &T->ir[irs->op1];
 	      TRef val, key = irr->op2, tmp = tr;
 	      if (irr->o != IR_FREF) {
@@ -729,7 +726,7 @@ static void snap_unsink(jit_State *J, GCtrace *T, ExitState *ex,
     } else {
       IRIns *irs, *irlast = &T->ir[T->snap[snapno].ref];
       for (irs = ir+1; irs < irlast; irs++)
-	if (irs->r == RID_SINK && snap_sunk_store(J, ir, irs)) {
+	if (irs->r == RID_SINK && snap_sunk_store(T, ir, irs)) {
 	  IRIns *iro = &T->ir[T->ir[irs->op1].op2];
 	  uint8_t *p = (uint8_t *)cd;
 	  CTSize szs;
@@ -762,7 +759,7 @@ static void snap_unsink(jit_State *J, GCtrace *T, ExitState *ex,
     settabV(J->L, o, t);
     irlast = &T->ir[T->snap[snapno].ref];
     for (irs = ir+1; irs < irlast; irs++)
-      if (irs->r == RID_SINK && snap_sunk_store(J, ir, irs)) {
+      if (irs->r == RID_SINK && snap_sunk_store(T, ir, irs)) {
 	IRIns *irk = &T->ir[irs->op1];
 	TValue tmp, *val;
 	lua_assert(irs->o == IR_ASTORE || irs->o == IR_HSTORE ||


### PR DESCRIPTION
Remove IR macro in lj_snap.c to avoid such errors in the future.

Fixes #82.