### PR TITLE
dump.lua must discard symbol table on 'flush' event.

### DIFF
--- a/src/jit/dump.lua
+++ b/src/jit/dump.lua
@@ -571,6 +571,11 @@ local function dump_trace(what, tr, func, pc, otr, oex)
     end
     if dumpmode.H then out:write("</pre>\n\n") else out:write("\n") end
   else
+    if what == "flush" then
+      -- Discard symbol table because exit stubs were discarded together
+      -- with traces. New exit stubs might have different addresses.
+      symtab, nexitsym = {}, 0
+    end
     out:write("---- TRACE ", what, "\n\n")
   end
   out:flush()


### PR DESCRIPTION
Exit stub groups are discarded together with traces and might end up
at a different address after the flush.