### PR TITLE
RFC: Compile string.find and string.match

### DIFF
--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -899,17 +899,62 @@ static void LJ_FASTCALL recff_string_op(jit_State *J, RecordFFData *rd)
   J->base[0] = emitir(IRT(IR_BUFSTR, IRT_STR), tr, hdr);
 }
 
-static void LJ_FASTCALL recff_string_find(jit_State *J, RecordFFData *rd)
+static int recff_emit_captures(jit_State *J, const MatchState *ms,
+				TRef tr, int off, TRef sptr)
 {
-  TRef trstr = lj_ir_tostr(J, J->base[0]);
-  TRef trpat = lj_ir_tostr(J, J->base[1]);
-  TRef trlen = emitir(IRTI(IR_FLOAD), trstr, IRFL_STR_LEN);
-  TRef tr0 = lj_ir_kint(J, 0);
+  TRef captures;
+  int i;
+  int capoff = offsetof(MatchState, capture[0]);
+  int capsize = sizeof(ms->capture[0]);
+  int initoff = offsetof(MatchState, capture[0].init) - capoff;
+  int lenoff = offsetof(MatchState, capture[0].len) - capoff;
+
+  if (!ms->level)
+    return 0;
+
+  captures = emitir(IRT(IR_ADD, IRT_P32), tr, /* IRFL_ not really applicable. */
+                    lj_ir_kint(J, capoff));
+  for (i = 0; i < ms->level; i++) {
+    int init = i*capsize+initoff;
+    if (ms->capture[i].len == CAP_POSITION) {
+      J->base[off+i] =
+        emitir(IRT(IR_SUB, IRT_INT),
+          emitir(IRT(IR_XLOAD, IRT_P32),
+            emitir(IRT(IR_ADD, IRT_P32), captures, lj_ir_kint(J, init)), 0),
+          emitir(IRT(IR_SUB, IRT_P32), sptr, lj_ir_kint(J, 1))
+        ); /* IR_SUB */
+    } else {
+      int len = i*capsize+lenoff;
+      J->base[off+i] =
+        emitir(IRT(IR_SNEW, IRT_STR),
+          emitir(IRT(IR_XLOAD, IRT_P32),
+            emitir(IRT(IR_ADD, IRT_P32), captures, lj_ir_kint(J, init)), 0),
+          emitir(IRT(IR_XLOAD, IRT_INT),
+            emitir(IRT(IR_ADD, IRT_P32), captures, lj_ir_kint(J, len)), 0)
+        ); /* IR_SNEW */
+    }
+  }
+  return ms->level;
+}
+
+static void LJ_FASTCALL recff_string_findmatch(jit_State *J, RecordFFData *rd)
+{
+  int find = rd->data;
+  TRef tr0, trstr, trsptr, trslen, trpat, trpptr;
   TRef trstart;
+  int32_t start;
   GCstr *str = argv2str(J, &rd->argv[0]);
   GCstr *pat = argv2str(J, &rd->argv[1]);
-  int32_t start;
+  TRef kpat = 0;
+  int rawfind = 0;
+
   J->needsnap = 1;
+
+  tr0 = lj_ir_kint(J, 0);
+  trstr = lj_ir_tostr(J, J->base[0]);
+  trpat = lj_ir_tostr(J, J->base[1]);
+
+  /* Optional start argument. */
   if (tref_isnil(J->base[2])) {
     trstart = lj_ir_kint(J, 1);
     start = 1;
@@ -917,44 +962,56 @@ static void LJ_FASTCALL recff_string_find(jit_State *J, RecordFFData *rd)
     trstart = lj_opt_narrow_toint(J, J->base[2]);
     start = argv2int(J, &rd->argv[2]);
   }
-  trstart = recff_string_start(J, str, &start, trstart, trlen, tr0);
-  if ((MSize)start <= str->len) {
-    emitir(IRTGI(IR_ULE), trstart, trlen);
-  } else {
-    emitir(IRTGI(IR_UGT), trstart, trlen);
-#if LJ_52
-    J->base[0] = TREF_NIL;
-    return;
-#else
-    trstart = trlen;
-    start = str->len;
-#endif
+
+  /* Specialize on pattern only if no raw flag is specified. */
+  if (!find || !(rawfind = (J->base[2] && tref_istruecond(J->base[3])))) {
+    kpat = lj_ir_kstr(J, pat);
+    emitir(IRTG(IR_EQ, IRT_STR), trpat, kpat);
+    trpat = kpat;
   }
-  /* Fixed arg or no pattern matching chars? (Specialized to pattern string.) */
-  if ((J->base[2] && tref_istruecond(J->base[3])) ||
-      (emitir(IRTG(IR_EQ, IRT_STR), trpat, lj_ir_kstr(J, pat)),
-       !lj_str_haspattern(pat))) {  /* Search for fixed string. */
-    TRef trsptr = emitir(IRT(IR_STRREF, IRT_P32), trstr, trstart);
-    TRef trpptr = emitir(IRT(IR_STRREF, IRT_P32), trpat, tr0);
-    TRef trslen = emitir(IRTI(IR_SUB), trlen, trstart);
+
+  trsptr = emitir(IRT(IR_STRREF, IRT_P32), trstr, tr0);
+  trslen = emitir(IRTI(IR_FLOAD), trstr, IRFL_STR_LEN);
+  trpptr = emitir(IRT(IR_STRREF, IRT_P32), trpat, tr0);
+
+  if (rawfind || !lj_str_haspattern(pat)) {
     TRef trplen = emitir(IRTI(IR_FLOAD), trpat, IRFL_STR_LEN);
-    TRef tr = lj_ir_call(J, IRCALL_lj_str_find, trsptr, trpptr, trslen, trplen);
+    TRef tr = lj_ir_call(J, IRCALL_lj_str_find,
+		    trsptr, trpptr, trslen, trplen, trstart);
+    if (lj_str_find(strdata(str), strdata(pat),
+		    str->len, pat->len, start)) {
+      emitir(IRTG(IR_NE, IRT_INT), tr, tr0);
+      if (!find)
+        J->base[0] = kpat;
+      else {
+        J->base[0] = tr;
+        J->base[1] = emitir(IRTI(IR_ADD), tr, emitir(IRTI(IR_SUB), trplen, 
+				lj_ir_kint(J, 1)));
+        rd->nres = 2;
+      }
+    } else {
+      emitir(IRTG(IR_EQ, IRT_INT), tr, tr0);
+      J->base[0] = TREF_NIL;
+    }
+  } else {
+    TRef tr = lj_ir_call(J, IRCALL_lj_str_match,
+		    trsptr, trpptr, trslen, trstart);
     TRef trp0 = lj_ir_kkptr(J, NULL);
-    if (lj_str_find(strdata(str)+(MSize)start, strdata(pat),
-		    str->len-(MSize)start, pat->len)) {
-      TRef pos;
+    MatchState *ms = lj_str_match(J->L, strdata(str), strdata(pat),
+		    str->len, start);
+    if (ms) {
+      int rpos = 0;
       emitir(IRTG(IR_NE, IRT_P32), tr, trp0);
-      pos = emitir(IRTI(IR_SUB), tr, emitir(IRT(IR_STRREF, IRT_P32), trstr, tr0));
-      J->base[0] = emitir(IRTI(IR_ADD), pos, lj_ir_kint(J, 1));
-      J->base[1] = emitir(IRTI(IR_ADD), pos, trplen);
-      rd->nres = 2;
+      if (find) {
+        J->base[0] = emitir(IRTI(IR_FLOAD), tr, IRFL_MS_FINDRET1);
+        J->base[1] = emitir(IRTI(IR_FLOAD), tr, IRFL_MS_FINDRET2);
+        rpos = 2;
+      }
+      rd->nres = rpos + recff_emit_captures(J, ms, tr, rpos, trsptr);
     } else {
       emitir(IRTG(IR_EQ, IRT_P32), tr, trp0);
       J->base[0] = TREF_NIL;
     }
-  } else {  /* Search for pattern. */
-    recff_nyiu(J, rd);
-    return;
   }
 }
 

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -209,7 +209,9 @@ IRFPMDEF(FPMENUM)
   _(CDATA_PTR,	sizeof(GCcdata)) \
   _(CDATA_INT, sizeof(GCcdata)) \
   _(CDATA_INT64, sizeof(GCcdata)) \
-  _(CDATA_INT64_4, sizeof(GCcdata) + 4)
+  _(CDATA_INT64_4, sizeof(GCcdata) + 4) \
+  _(MS_FINDRET1,offsetof(MatchState, findret1)) \
+  _(MS_FINDRET2,offsetof(MatchState, findret2)) \
 
 typedef enum {
 #define FLENUM(name, ofs)	IRFL_##name,

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -123,7 +123,8 @@ typedef struct CCallInfo {
 /* Function definitions for CALL* instructions. */
 #define IRCALLDEF(_) \
   _(ANY,	lj_str_cmp,		2,  FN, INT, CCI_NOFPRCLOBBER) \
-  _(ANY,	lj_str_find,		4,   N, P32, 0) \
+  _(ANY, 	lj_str_match, 		5,   N, P32, CCI_L) \
+  _(ANY,	lj_str_find,		5,   N, INT, 0) \
   _(ANY,	lj_str_new,		3,   S, STR, CCI_L) \
   _(ANY,	lj_strscan_num,		2,  FN, INT, 0) \
   _(ANY,	lj_strfmt_int,		2,  FN, STR, CCI_L) \

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -590,6 +590,23 @@ typedef struct GCState {
   MSize pause;		/* Pause between successive GC cycles. */
 } GCState;
 
+/* Match state for pattern captures. */
+typedef struct MatchState {
+  const char *src_init; /* Start of source string. */
+  const char *src_end;  /* End (`\0') of source string. */
+  lua_State *L;
+  int level; 		/* Total number of captures (finished or unfinished). */
+  int depth;
+  uint32_t findret1;
+  uint32_t findret2; 	/* Return indices of string.find(). */
+  struct {
+    MRef init;
+    MSize len;
+  } capture[LUA_MAXCAPTURES];
+} MatchState;
+#define CAP_UNFINISHED	((MSize)(-1))
+#define CAP_POSITION	((MSize)(-2))
+
 /* Global state, shared by all threads of a Lua universe. */
 typedef struct global_State {
   GCRef *strhash;	/* String hash table (hash chain anchors). */
@@ -621,6 +638,7 @@ typedef struct global_State {
   MRef jit_base;	/* Current JIT code L->base or NULL. */
   MRef ctype_state;	/* Pointer to C type state. */
   GCRef gcroot[GCROOT_MAX];  /* GC roots. */
+  MatchState ms; 	/* Capture buffer for JIT mcode. */
 } global_State;
 
 #define mainthread(g)	(&gcref(g->mainthref)->th)

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -12,9 +12,11 @@
 
 /* String helpers. */
 LJ_FUNC int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b);
-LJ_FUNC const char *lj_str_find(const char *s, const char *f,
-				MSize slen, MSize flen);
+LJ_FUNC uint32_t lj_str_find(const char *s, const char *p, MSize slen,
+				MSize plen, int32_t start);
 LJ_FUNC int lj_str_haspattern(GCstr *s);
+LJ_FUNC MatchState * lj_str_match(lua_State *L, const char *s, const char *p,
+				MSize slen, int32_t start);
 
 /* String interning. */
 LJ_FUNC void lj_str_resize(lua_State *L, MSize newmask);


### PR DESCRIPTION
- string.find and string.match are now always compiled
- ~~In 5.2 emulation mode, \0s should not terminate patterns~~ - separated
- ~~Limit number of pattern backtraces to prevent ReDoS~~ - separated

~~In synthetic tests, the JIT inline makes string.find/match about a magnitude faster as there is no costly stitching involved anymore - https://gist.githubusercontent.com/katlogic/fe43120beb172a3dff51/raw/9d9f2a81c99fad30938c8600c11423a72734dc30/patbench.txt~~ see comments

Benefit of compiling gsub and gmatch is dubious as those are often used with function argument - the implementation would be much more complex and the result would not be much better than stitching. Not worth it.

Parts of the code are somewhat sketchy and could use some polish:
- recff_emit_captures should be probably rewritten to something more idiomatic
- ~~find/match jit recording code could be partially collapsed~~ done
- lj_str_match prototype in lj_str.h is not pretty, alternative would be inventing new header file or moving whole pattern matcher into lj_str.c
