### PR TITLE
RFC: String buffer implementation 

### DIFF
--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -944,7 +944,7 @@ LJLIB_CF(stringbuf_upper) LJLIB_REC(stringbuf_op IRCALL_lj_buf_upper)
   return 0;
 }
 
-LJLIB_CF(stringbuf_byte)
+LJLIB_CF(stringbuf_byte) LJLIB_REC(stringbuf_byte 0)
 {
   SBuf *sb = check_bufarg(L);
   int32_t pos = lj_lib_checkint(L, 2);
@@ -962,7 +962,7 @@ LJLIB_CF(stringbuf_byte)
   return 1;
 }
 
-LJLIB_CF(stringbuf_setbyte)
+LJLIB_CF(stringbuf_setbyte) LJLIB_REC(stringbuf_byte 1)
 {
   SBuf *sb = check_bufarg(L);
   int32_t pos = lj_lib_checkint(L, 2);
@@ -992,7 +992,7 @@ LJLIB_CF(stringbuf_setbyte)
   return 0;
 }
 
-LJLIB_CF(stringbuf_len)
+LJLIB_CF(stringbuf_len)  LJLIB_REC(stringbuf_info 0)
 {
   SBuf *sb = check_bufarg(L);
   setintV(L->top - 1, sbuflen(sb));
@@ -1027,7 +1027,7 @@ LJLIB_CF(stringbuf_setlength)
   return 0;
 }
 
-LJLIB_CF(stringbuf_capacity)
+LJLIB_CF(stringbuf_capacity)  LJLIB_REC(stringbuf_info 1)
 {
   SBuf *sb = check_bufarg(L);
   setintV(L->top - 1, sbufsz(sb));

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -120,7 +120,7 @@ static int string_rep(lua_State *L, int isstrbuf)
   return 1;
 }
 
-LJLIB_CF(string_rep)		LJLIB_REC(string_rep)
+LJLIB_CF(string_rep)		LJLIB_REC(string_rep 0)
 {
   return string_rep(L, 0);
 }
@@ -783,7 +783,7 @@ again:
   return 1;
 }
 
-LJLIB_CF(string_format)		LJLIB_REC(.)
+LJLIB_CF(string_format)		 LJLIB_REC(string_format 0)
 {
   return string_format(L, 0);
 }
@@ -810,7 +810,7 @@ LJLIB_CF(string_createbuffer)
 
 #define LJLIB_MODULE_stringbuf
 
-LJLIB_CF(stringbuf_format)
+LJLIB_CF(stringbuf_format)  LJLIB_REC(string_format 1)
 {
   return string_format(L, 1);
 }
@@ -918,7 +918,7 @@ LJLIB_CF(stringbuf_writesub)  LJLIB_REC(stringbuf_writerange)
   return 0;
 }
 
-LJLIB_CF(stringbuf_rep)
+LJLIB_CF(stringbuf_rep)  LJLIB_REC(string_rep 1)
 {
   return string_rep(L, 1);
 }

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -1048,14 +1048,23 @@ LJLIB_CF(stringbuf_reserve) LJLIB_REC(.)
   return 0;
 }
 
-LJLIB_CF(stringbuf_equals)
+LJLIB_CF(stringbuf_equals) LJLIB_REC(.)
 {
   MSize len;
   SBuf *sb = check_bufarg(L);
   const char* s = lj_lib_checkstrorsbuf(L, 2, &len);
 
-  int eq = len == sbuflen(sb) && strncmp(s, sbufB(sb), len) == 0;
-  setboolV(L->top - 1, eq);
+  int b = 0;
+
+  if (len == sbuflen(sb)) {
+    if (tvisstr(L->base+1)) {
+      b = lj_str_eqbuf(strV(L->base+1), sb);
+    } else {
+      b = lj_buf_eq(sb, sbufV(L->base+1));
+    }
+  }
+
+  setboolV(L->top - 1, b);
   return 1;
 }
 

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -908,6 +908,27 @@ LJLIB_CF(stringbuf_rep)
   return string_rep(L, 1);
 }
 
+LJLIB_CF(stringbuf_reverse)
+{
+  SBuf *sb = check_bufarg(L);
+  lj_buf_reverse(sb);
+  return 0;
+}
+
+LJLIB_CF(stringbuf_lower)
+{
+  SBuf *sb = check_bufarg(L);
+  lj_buf_lower(sb);
+  return 0;
+}
+
+LJLIB_CF(stringbuf_upper)
+{
+  SBuf *sb = check_bufarg(L);
+  lj_buf_upper(sb);
+  return 0;
+}
+
 LJLIB_CF(stringbuf_byte)
 {
   SBuf *sb = check_bufarg(L);

--- a/src/lib_string.c
+++ b/src/lib_string.c
@@ -893,20 +893,20 @@ static SBuf *stringbuf_write(lua_State *L)
   return sb;
 }
 
-LJLIB_CF(stringbuf_write)
+LJLIB_CF(stringbuf_write)  LJLIB_REC(stringbuf_write 0)
 {
   stringbuf_write(L);
   return 0;
 }
 
-LJLIB_CF(stringbuf_writeln)
+LJLIB_CF(stringbuf_writeln)  LJLIB_REC(stringbuf_write 1)
 {
   SBuf *sb = stringbuf_write(L);
   lj_buf_putb(sb, '\n');
   return 0;
 }
 
-LJLIB_CF(stringbuf_writesub)
+LJLIB_CF(stringbuf_writesub)  LJLIB_REC(stringbuf_writerange)
 {
   MSize len;
   SBuf *sb = check_bufarg(L);
@@ -923,21 +923,21 @@ LJLIB_CF(stringbuf_rep)
   return string_rep(L, 1);
 }
 
-LJLIB_CF(stringbuf_reverse)
+LJLIB_CF(stringbuf_reverse) LJLIB_REC(stringbuf_op IRCALL_lj_buf_reverse)
 {
   SBuf *sb = check_bufarg(L);
   lj_buf_reverse(sb);
   return 0;
 }
 
-LJLIB_CF(stringbuf_lower)
+LJLIB_CF(stringbuf_lower)  LJLIB_REC(stringbuf_op IRCALL_lj_buf_lower)
 {
   SBuf *sb = check_bufarg(L);
   lj_buf_lower(sb);
   return 0;
 }
 
-LJLIB_CF(stringbuf_upper)
+LJLIB_CF(stringbuf_upper) LJLIB_REC(stringbuf_op IRCALL_lj_buf_upper)
 {
   SBuf *sb = check_bufarg(L);
   lj_buf_upper(sb);
@@ -1058,21 +1058,21 @@ LJLIB_CF(stringbuf_equals)
   return 1;
 }
 
-LJLIB_CF(stringbuf_reset)
+LJLIB_CF(stringbuf_reset)  LJLIB_REC(.)
 {
   SBuf *sb = check_bufarg(L);
   lj_buf_reset(sb);
   return 0;
 }
 
-LJLIB_CF(stringbuf_tostring)
+LJLIB_CF(stringbuf_tostring)  LJLIB_REC(.)
 {
   SBuf *sb = check_bufarg(L);
   setstrV(L, L->top - 1, lj_buf_str(L, sb));
   return 1;
 }
 
-LJLIB_CF(stringbuf___tostring)
+LJLIB_CF(stringbuf___tostring)  LJLIB_REC(stringbuf_tostring)
 {
   SBuf *sb = check_bufarg(L);
   setstrV(L, L->top - 1, lj_buf_str(L, sb));

--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -1614,7 +1614,7 @@ static void asm_ir(ASMState *as, IRIns *ir)
   /* Miscellaneous ops. */
   case IR_LOOP: asm_loop(as); break;
   case IR_NOP: case IR_XBAR: lua_assert(!ra_used(ir)); break;
-  case IR_USE:
+  case IR_USE: case IR_BUFTL:
     ra_alloc1(as, ir->op1, irt_isfp(ir->t) ? RSET_FPR : RSET_GPR); break;
   case IR_PHI: asm_phi(as, ir); break;
   case IR_HIOP: asm_hiop(as, ir); break;

--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -1089,12 +1089,12 @@ static void asm_tvptr(ASMState *as, Reg dest, IRRef ref);
 static void asm_bufhdr(ASMState *as, IRIns *ir)
 {
   Reg sb = ra_dest(as, ir, RSET_GPR);
-  if ((ir->op2 & IRBUFHDR_APPEND)) {
+  if ((ir->op2 & IRBUFHDR_MODEMASK) != IRBUFHDR_RESET) {
     /* Rematerialize const buffer pointer instead of likely spill. */
     IRIns *irp = IR(ir->op1);
-    if (!(ra_hasreg(irp->r) || irp == ir-1 ||
+    if (!(ir->op2 & IRBUFHDR_STRBUF) && !(ra_hasreg(irp->r) || irp == ir-1 ||
 	  (irp == ir-2 && !ra_used(ir-1)))) {
-      while (!(irp->o == IR_BUFHDR && !(irp->op2 & IRBUFHDR_APPEND)))
+      while (!(irp->o == IR_BUFHDR && (irp->op2 & IRBUFHDR_MODEMASK) == IRBUFHDR_RESET))
 	irp = IR(irp->op1);
       if (irref_isk(irp->op1)) {
 	ra_weak(as, ra_allocref(as, ir->op1, RSET_GPR));

--- a/src/lj_buf.c
+++ b/src/lj_buf.c
@@ -174,6 +174,19 @@ SBuf *lj_buf_putrang(SBuf *sb, const char* s, MSize len, int32_t start, int32_t 
 
   return sb;
 }
+
+SBuf *lj_buf_putbuf_range(SBuf *sb, SBuf *sbsrc, int32_t start, int32_t end)
+{
+  lj_buf_putrang(sb, sbufB(sbsrc), sbuflen(sbsrc), start, end);
+  return sb;
+}
+
+SBuf *lj_buf_putstr_range(SBuf *sb, GCstr *s, int32_t start, int32_t end)
+{
+  lj_buf_putrang(sb, strdata(s), s->len, start, end);
+  return sb;
+}
+
 /* -- High-level buffer put operations ------------------------------------ */
 
 SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s)

--- a/src/lj_buf.c
+++ b/src/lj_buf.c
@@ -94,6 +94,36 @@ SBuf * LJ_FASTCALL lj_buf_putstr(SBuf *sb, GCstr *s)
   return sb;
 }
 
+SBuf * LJ_FASTCALL lj_buf_putbuf(SBuf *sb, SBuf *sb2)
+{
+  MSize len = sbuflen(sb2);
+  char *p = lj_buf_more(sb, len);
+  p = lj_buf_wmem(p, sbufB(sb2), len);
+  setsbufP(sb, p);
+  return sb;
+}
+
+static LJ_AINLINE int32_t posrelat(int32_t pos, MSize len)
+{
+  /* relative string position: negative means back from end */
+  if (pos < 0) pos += len + 1;
+  return (pos >= 0) ? pos : 0;
+}
+
+SBuf *lj_buf_putrang(SBuf *sb, const char* s, MSize len, int32_t start, int32_t end)
+{
+  start = posrelat(start, len);
+  end = posrelat(end, len);
+
+  if (start < 1) start = 1;
+  if (end > (int32_t)len) end = (int32_t)len;
+
+  if (start <= end) {
+    lj_buf_putmem(sb, s + start - 1, end - start + 1);
+  }
+
+  return sb;
+}
 /* -- High-level buffer put operations ------------------------------------ */
 
 SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s)

--- a/src/lj_buf.c
+++ b/src/lj_buf.c
@@ -47,6 +47,14 @@ LJ_NOINLINE char *LJ_FASTCALL lj_buf_more2(SBuf *sb, MSize sz)
   return sbufP(sb);
 }
 
+SBuf *LJ_FASTCALL lj_buf_reserve(SBuf *sb, MSize sz)
+{
+  if (sz > sbufleft(sb)) {
+    lj_buf_more2(sb, sz);
+  }
+  return sb;
+}
+
 void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb)
 {
   char *b = sbufB(sb);
@@ -58,6 +66,20 @@ void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb)
     setmref(sb->p, b + n);
     setmref(sb->e, b + (osz >> 1));
   }
+}
+
+SBuf* lj_buf_setlen(SBuf *sb, MSize len, int fill)
+{
+  MSize oldlen = sbuflen(sb);
+  lua_assert(len <= sbufsz(sb));
+
+  setsbuflen(sb, len);
+
+  if (len > oldlen && fill != -1) {
+    memset(sbufB(sb) + oldlen, fill, len-oldlen);
+  }
+
+  return sb;
 }
 
 char * LJ_FASTCALL lj_buf_tmp(lua_State *L, MSize sz)

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -83,6 +83,11 @@ static LJ_AINLINE void lj_buf_putb(SBuf *sb, int c)
   setsbufP(sb, p);
 }
 
+/* In-place buffer operations */
+LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_upper(SBuf *sb);
+LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_lower(SBuf *sb);
+LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_reverse(SBuf *sb);
+
 /* High-level buffer put operations */
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s);

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -111,6 +111,7 @@ LJ_FUNC SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep,
 
 /* Miscellaneous buffer operations */
 LJ_FUNCA GCstr * LJ_FASTCALL lj_buf_tostr(SBuf *sb);
+LJ_FUNCA int LJ_FASTCALL lj_buf_eq(SBuf *sb1, SBuf *sb2);
 LJ_FUNC GCstr *lj_buf_cat2str(lua_State *L, GCstr *s1, GCstr *s2);
 LJ_FUNC uint32_t LJ_FASTCALL lj_buf_ruleb128(const char **pp);
 

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -100,6 +100,8 @@ LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_upper(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putbuf(SBuf *sb, SBuf *sb2);
+LJ_FUNCA SBuf *lj_buf_putbuf_range(SBuf *sb, SBuf *sbsrc, int32_t start, int32_t end);
+LJ_FUNCA SBuf *lj_buf_putstr_range(SBuf *sb, GCstr *s, int32_t start, int32_t end);
 LJ_FUNCA SBuf *lj_buf_putrang(SBuf *sb, const char *s, MSize len, int32_t start, int32_t end);
 LJ_FUNC SBuf *lj_buf_putstr_rep(SBuf *sb, GCstr *s, int32_t rep);
 LJ_FUNC SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep,

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -71,6 +71,13 @@ LJ_FUNC SBuf *lj_buf_putmem(SBuf *sb, const void *q, MSize len);
 LJ_FUNC SBuf * LJ_FASTCALL lj_buf_putchar(SBuf *sb, int c);
 LJ_FUNC SBuf * LJ_FASTCALL lj_buf_putstr(SBuf *sb, GCstr *s);
 
+/* add a temporary null terminator after the last character in the buffer without advancing the position */
+static LJ_AINLINE SBuf *lj_buf_nullterm(SBuf *sb)
+{
+  *lj_buf_more(sb, 1) = 0;
+  return sb;
+}
+
 static LJ_AINLINE char *lj_buf_wmem(char *p, const void *q, MSize len)
 {
   return (char *)memcpy(p, q, len) + len;

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -25,7 +25,9 @@
 /* Buffer management */
 LJ_FUNC char *LJ_FASTCALL lj_buf_need2(SBuf *sb, MSize sz);
 LJ_FUNC char *LJ_FASTCALL lj_buf_more2(SBuf *sb, MSize sz);
+LJ_FUNC SBuf *LJ_FASTCALL lj_buf_reserve(SBuf *sb, MSize sz);
 LJ_FUNC void LJ_FASTCALL lj_buf_shrink(lua_State *L, SBuf *sb);
+LJ_FUNC SBuf *lj_buf_setlen(SBuf *sb, MSize len, int fill);
 LJ_FUNC char * LJ_FASTCALL lj_buf_tmp(lua_State *L, MSize sz);
 
 static LJ_AINLINE void lj_buf_init(lua_State *L, SBuf *sb)

--- a/src/lj_buf.h
+++ b/src/lj_buf.h
@@ -19,6 +19,7 @@
 #define sbuflen(sb)	((MSize)(sbufP((sb)) - sbufB((sb))))
 #define sbufleft(sb)	((MSize)(sbufE((sb)) - sbufP((sb))))
 #define setsbufP(sb, q)	(setmref((sb)->p, (q)))
+#define setsbuflen(sb, len) (setmref((sb)->p, (sbufB(sb)+len)))
 #define setsbufL(sb, l)	(setmref((sb)->L, (l)))
 
 /* Buffer management */
@@ -86,6 +87,8 @@ static LJ_AINLINE void lj_buf_putb(SBuf *sb, int c)
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_reverse(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_lower(SBuf *sb, GCstr *s);
 LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putstr_upper(SBuf *sb, GCstr *s);
+LJ_FUNCA SBuf * LJ_FASTCALL lj_buf_putbuf(SBuf *sb, SBuf *sb2);
+LJ_FUNCA SBuf *lj_buf_putrang(SBuf *sb, const char *s, MSize len, int32_t start, int32_t end);
 LJ_FUNC SBuf *lj_buf_putstr_rep(SBuf *sb, GCstr *s, int32_t rep);
 LJ_FUNC SBuf *lj_buf_puttab(SBuf *sb, GCtab *t, GCstr *sep,
 			    int32_t i, int32_t e);

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -1022,7 +1022,7 @@ static void LJ_FASTCALL recff_string_format(jit_State *J, RecordFFData *rd)
       if (sf == STRFMT_STR)  /* Shortcut for plain %s. */
 	tr = emitir(IRT(IR_BUFPUT, IRT_PGC), tr, tra);
       else if ((sf & STRFMT_T_QUOTED))
-	tr = lj_ir_call(J, IRCALL_lj_strfmt_putquoted, tr, tra);
+	tr = lj_ir_call(J, IRCALL_lj_strfmt_putquotedstr, tr, tra);
       else
 	tr = lj_ir_call(J, IRCALL_lj_strfmt_putfstr, tr, trsf, tra);
       break;

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -206,6 +206,9 @@ IRFPMDEF(FPMENUM)
   _(UDATA_META,	offsetof(GCudata, metatable)) \
   _(UDATA_UDTYPE, offsetof(GCudata, udtype)) \
   _(UDATA_FILE,	sizeof(GCudata)) \
+  _(SBUF_B,     offsetof(SBuf, b)) \
+  _(SBUF_P,     offsetof(SBuf, p)) \
+  _(SBUF_E,     offsetof(SBuf, e)) \
   _(CDATA_CTYPEID, offsetof(GCcdata, ctypeid)) \
   _(CDATA_PTR,	sizeof(GCcdata)) \
   _(CDATA_INT, sizeof(GCcdata)) \

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -234,6 +234,10 @@ IRFLDEF(FLENUM)
 /* BUFHDR mode, stored in op2. */
 #define IRBUFHDR_RESET		0	/* Reset buffer. */
 #define IRBUFHDR_APPEND		1	/* Append to buffer. */
+#define IRBUFHDR_MODIFY         2       /* Direct modification to buffer. barrier to folding two separate chains for the same buffer */
+#define IRBUFHDR_RESIZE         3
+#define IRBUFHDR_MODEMASK       7 
+#define IRBUFHDR_STRBUF         8       /* buffer is a userdata string buffer. */
 
 /* CONV mode, stored in op2. */
 #define IRCONV_SRCMASK		0x001f	/* Source IRType. */

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -124,6 +124,7 @@
   \
   /* Buffer operations. */ \
   _(BUFHDR,	L , ref, lit) \
+  _(BUFTL,      S , ref, ref) \
   _(BUFPUT,	L , ref, ref) \
   _(BUFSTR,	A , ref, ref) \
   \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -151,6 +151,7 @@ typedef struct CCallInfo {
   _(ANY,	lj_strfmt_putfnum_uint,	3,   L, PGC, XA_FP) \
   _(ANY,	lj_strfmt_putfnum,	3,   L, PGC, XA_FP) \
   _(ANY,	lj_strfmt_putfstr,	3,   L, PGC, 0) \
+  _(ANY,	lj_strfmt_putfbuf,	3,   L, PGC, 0) \
   _(ANY,	lj_strfmt_putfchar,	3,   L, PGC, 0) \
   _(ANY,	lj_buf_lower,		1,  FL, PGC, 0) \
   _(ANY,	lj_buf_upper,		1,  FL, PGC, 0) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -168,6 +168,8 @@ typedef struct CCallInfo {
   _(ANY,	lj_buf_putstr_rep,	3,   L, PGC, 0) \
   _(ANY,	lj_buf_puttab,		5,   L, PGC, 0) \
   _(ANY,	lj_buf_tostr,		1,  FL, STR, 0) \
+  _(ANY,	lj_buf_setlen,		3,  S,  P32, 0) \
+  _(ANY,	lj_buf_reserve,		2,  FS, P32, 0) \
   _(ANY,	lj_tab_new_ah,		3,   A, TAB, CCI_L) \
   _(ANY,	lj_tab_new1,		2,  FS, TAB, CCI_L) \
   _(ANY,	lj_tab_dup,		2,  FS, TAB, CCI_L) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -152,8 +152,14 @@ typedef struct CCallInfo {
   _(ANY,	lj_strfmt_putfnum,	3,   L, PGC, XA_FP) \
   _(ANY,	lj_strfmt_putfstr,	3,   L, PGC, 0) \
   _(ANY,	lj_strfmt_putfchar,	3,   L, PGC, 0) \
+  _(ANY,	lj_buf_lower,		1,  FL, PGC, 0) \
+  _(ANY,	lj_buf_upper,		1,  FL, PGC, 0) \
+  _(ANY,	lj_buf_reverse,		1,  FL, PGC, 0) \
   _(ANY,	lj_buf_putmem,		3,   S, PGC, 0) \
-  _(ANY,	lj_buf_putstr,		2,  FL, PGC, 0) \
+  _(ANY,	lj_buf_putstr_range,	4,   L, PGC, 0) \
+  _(ANY,	lj_buf_putbuf_range,	4,   L, PGC, 0) \
+  _(ANY,	lj_buf_putstr,          2,  FL, PGC, 0) \
+  _(ANY,	lj_buf_putbuf,		2,  FL, PGC, 0) \
   _(ANY,	lj_buf_putchar,		2,  FL, PGC, 0) \
   _(ANY,	lj_buf_putstr_reverse,	2,  FL, PGC, 0) \
   _(ANY,	lj_buf_putstr_lower,	2,  FL, PGC, 0) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -137,6 +137,8 @@ typedef struct CCallInfo {
 /* Function definitions for CALL* instructions. */
 #define IRCALLDEF(_) \
   _(ANY,	lj_str_cmp,		2,  FN, INT, CCI_NOFPRCLOBBER) \
+  _(ANY,	lj_str_eqbuf,        2,  FN, INT, 0) \
+  _(ANY,	lj_buf_eq,		2,  FN, INT, 0) \
   _(ANY,	lj_str_find,		4,   N, PGC, 0) \
   _(ANY,	lj_str_new,		3,   S, STR, CCI_L) \
   _(ANY,	lj_strscan_num,		2,  FN, INT, 0) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -145,7 +145,7 @@ typedef struct CCallInfo {
   _(ANY,	lj_strfmt_char,		2,  FN, STR, CCI_L) \
   _(ANY,	lj_strfmt_putint,	2,  FL, PGC, 0) \
   _(ANY,	lj_strfmt_putnum,	2,  FL, PGC, 0) \
-  _(ANY,	lj_strfmt_putquoted,	2,  FL, PGC, 0) \
+  _(ANY,	lj_strfmt_putquotedstr,	2,  FL, PGC, 0) \
   _(ANY,	lj_strfmt_putfxint,	3,   L, PGC, XA_64) \
   _(ANY,	lj_strfmt_putfnum_int,	3,   L, PGC, XA_FP) \
   _(ANY,	lj_strfmt_putfnum_uint,	3,   L, PGC, XA_FP) \

--- a/src/lj_lib.c
+++ b/src/lj_lib.c
@@ -19,6 +19,7 @@
 #include "lj_vm.h"
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
+#include "lj_buf.h"
 #include "lj_lex.h"
 #include "lj_bcdump.h"
 #include "lj_lib.h"
@@ -202,6 +203,26 @@ GCstr *lj_lib_checkstr(lua_State *L, int narg)
     }
   }
   lj_err_argt(L, narg, LUA_TSTRING);
+  return NULL;  /* unreachable */
+}
+
+const char *lj_lib_checkstrorsbuf(lua_State *L, int narg, MSize *len)
+{
+  TValue *o = L->base + narg - 1;
+  if (o < L->top) {
+    if (tvisstr(o)) {
+      *len = strV(o)->len;
+      return strVdata(o);
+    } else if (tvissbuf(o)) {
+      SBuf *sb = sbufV(o);
+      *len = sbuflen(sb);
+      if (sbufB(sb) == NULL)
+        return "";
+      else
+        return sbufB(sb);
+    }
+  }
+  lj_err_argtype(L, narg, "string or stringbuffer");
   return NULL;  /* unreachable */
 }
 

--- a/src/lj_lib.h
+++ b/src/lj_lib.h
@@ -32,6 +32,7 @@
 
 LJ_FUNC TValue *lj_lib_checkany(lua_State *L, int narg);
 LJ_FUNC GCstr *lj_lib_checkstr(lua_State *L, int narg);
+LJ_FUNC const char *lj_lib_checkstrorsbuf(lua_State *L, int narg, MSize *len);
 LJ_FUNC GCstr *lj_lib_optstr(lua_State *L, int narg);
 #if LJ_DUALNUM
 LJ_FUNC void lj_lib_checknumber(lua_State *L, int narg);

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -319,6 +319,7 @@ typedef struct GCudata {
 enum {
   UDTYPE_USERDATA,	/* Regular userdata. */
   UDTYPE_IO_FILE,	/* I/O library FILE. */
+  UDTYPE_STRING_BUF,    /* String buffer */
   UDTYPE_FFI_CLIB,	/* FFI C library namespace. */
   UDTYPE__MAX
 };
@@ -766,6 +767,7 @@ typedef union GCobj {
 #define tvispri(o)	(itype(o) >= LJ_TISPRI)
 #define tvistabud(o)	(itype(o) <= LJ_TISTABUD)  /* && !tvisnum() */
 #define tvisgcv(o)	((itype(o) - LJ_TISGCV) > (LJ_TNUMX - LJ_TISGCV))
+#define tvissbuf(o)     (tvisudata(o) && udataV(o)->udtype == UDTYPE_STRING_BUF)
 
 /* Special macros to test numbers for NaN, +0, -0, +1 and raw equality. */
 #define tvisnan(o)	((o)->n != (o)->n)
@@ -808,6 +810,7 @@ typedef union GCobj {
 #define cdataV(o)	check_exp(tviscdata(o), &gcval(o)->cd)
 #define tabV(o)		check_exp(tvistab(o), &gcval(o)->tab)
 #define udataV(o)	check_exp(tvisudata(o), &gcval(o)->ud)
+#define sbufV(o)        check_exp(tvissbuf(o), (SBuf *)uddata(&gcval(o)->ud))
 #define numV(o)		check_exp(tvisnum(o), (o)->n)
 #define intV(o)		check_exp(tvisint(o), (int32_t)(o)->i)
 

--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -550,6 +550,42 @@ LJFOLDF(kfold_strcmp)
 ** fragments left over from CSE are eliminated by DCE.
 */
 
+LJFOLD(BUFHDR any any)
+LJFOLDF(bufhdr_fold)
+{
+  /* Reuse the last header for this buffer if its also a IRBUFHDR_MODIFY */
+  if (LJ_LIKELY(J->flags & JIT_F_OPT_FOLD) &&
+    fins->op2 == (IRBUFHDR_STRBUF|IRBUFHDR_MODIFY) && J->chain[IR_BUFHDR]) {
+    IRRef ref = J->chain[IR_BUFHDR];
+
+    /* Ignore the temp buffer since it can never be used in IRBUFHDR_MODIFY mode */
+    while (ref && (!(IR(ref)->op2 & IRBUFHDR_STRBUF) ||
+                    (IR(ref)->op2 & IRBUFHDR_MODEMASK) == IRBUFHDR_MODIFY)) {
+      if (IR(ref)->op1 == fins->op1) {
+        return ref;
+      }
+      ref = IR(ref)->prev;
+    }
+  }
+
+  return EMITFOLD;
+}
+
+LJFOLD(FLOAD any IRFL_SBUF_B)
+LJFOLD(FLOAD any IRFL_SBUF_P)
+LJFOLD(FLOAD any IRFL_SBUF_E)
+LJFOLDF(buf_fload)
+{
+  lua_assert(fleft->o == IR_BUFHDR && 
+             (fleft->op2&IRBUFHDR_MODEMASK) == IRBUFHDR_MODIFY);
+
+  if (LJ_LIKELY(J->flags & JIT_F_OPT_CSE)) {
+    /* CSE limited up to our header for now */
+    return lj_opt_cselim(J, fins->op1);
+  }
+  return EMITFOLD;
+}
+
 /* BUFHDR is emitted like a store, see below. */
 
 LJFOLD(BUFPUT BUFHDR BUFSTR)
@@ -2410,7 +2446,6 @@ LJFOLD(TNEW any any)
 LJFOLD(TDUP any)
 LJFOLD(CNEW any any)
 LJFOLD(XSNEW any any)
-LJFOLD(BUFHDR any any)
 LJFOLDX(lj_ir_emit)
 
 /* ------------------------------------------------------------------------ */

--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -577,7 +577,8 @@ LJFOLD(FLOAD any IRFL_SBUF_E)
 LJFOLDF(buf_fload)
 {
   lua_assert(fleft->o == IR_BUFHDR && 
-             (fleft->op2&IRBUFHDR_MODEMASK) == IRBUFHDR_MODIFY);
+             ((fleft->op2 & IRBUFHDR_MODEMASK) == IRBUFHDR_MODIFY || 
+              (fleft->op2 & IRBUFHDR_MODEMASK) == IRBUFHDR_RESIZE));
 
   if (LJ_LIKELY(J->flags & JIT_F_OPT_CSE)) {
     /* CSE limited up to our header for now */

--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -631,7 +631,7 @@ LJFOLDF(bufstr_kfold_cse)
 LJFOLD(CALLL CARG IRCALL_lj_buf_putstr_reverse)
 LJFOLD(CALLL CARG IRCALL_lj_buf_putstr_upper)
 LJFOLD(CALLL CARG IRCALL_lj_buf_putstr_lower)
-LJFOLD(CALLL CARG IRCALL_lj_strfmt_putquoted)
+LJFOLD(CALLL CARG IRCALL_lj_strfmt_putquotedstr)
 LJFOLDF(bufput_kfold_op)
 {
   if (irref_isk(fleft->op2)) {

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -12,6 +12,7 @@
 
 /* String helpers. */
 LJ_FUNC int32_t LJ_FASTCALL lj_str_cmp(GCstr *a, GCstr *b);
+LJ_FUNC int32_t LJ_FASTCALL lj_str_eqbuf(GCstr *s, SBuf *sb);
 LJ_FUNC const char *lj_str_find(const char *s, const char *f,
 				MSize slen, MSize flen);
 LJ_FUNC int lj_str_haspattern(GCstr *s);

--- a/src/lj_strfmt.c
+++ b/src/lj_strfmt.c
@@ -264,6 +264,11 @@ SBuf *lj_strfmt_putfstr(SBuf *sb, SFormat sf, GCstr *str)
   return lj_strfmt_putf(sb, sf, strdata(str), str->len);
 }
 
+SBuf *lj_strfmt_putfbuf(SBuf *sb, SFormat sf, SBuf *sb2)
+{
+  return lj_strfmt_putf(sb, sf, sbufB(sb2), sbuflen(sb2));
+}
+
 /* Add formatted signed/unsigned integer to buffer. */
 SBuf *lj_strfmt_putfxint(SBuf *sb, SFormat sf, uint64_t k)
 {

--- a/src/lj_strfmt.h
+++ b/src/lj_strfmt.h
@@ -94,7 +94,8 @@ LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putint(SBuf *sb, int32_t k);
 LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putnum(SBuf *sb, cTValue *o);
 #endif
 LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putptr(SBuf *sb, const void *v);
-LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putquoted(SBuf *sb, GCstr *str);
+LJ_FUNC SBuf * lj_strfmt_putquoted(SBuf *sb, const char *s, MSize len);
+LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putquotedstr(SBuf *sb, GCstr *str);
 
 /* Formatted conversions to buffer. */
 LJ_FUNC SBuf *lj_strfmt_putfxint(SBuf *sb, SFormat sf, uint64_t k);
@@ -102,6 +103,7 @@ LJ_FUNC SBuf *lj_strfmt_putfnum_int(SBuf *sb, SFormat sf, lua_Number n);
 LJ_FUNC SBuf *lj_strfmt_putfnum_uint(SBuf *sb, SFormat sf, lua_Number n);
 LJ_FUNC SBuf *lj_strfmt_putfnum(SBuf *sb, SFormat, lua_Number n);
 LJ_FUNC SBuf *lj_strfmt_putfchar(SBuf *sb, SFormat, int32_t c);
+LJ_FUNC SBuf *lj_strfmt_putf(SBuf *sb, SFormat, const char *s, MSize len);
 LJ_FUNC SBuf *lj_strfmt_putfstr(SBuf *sb, SFormat, GCstr *str);
 
 /* Conversions to strings. */

--- a/src/lj_strfmt.h
+++ b/src/lj_strfmt.h
@@ -96,6 +96,7 @@ LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putnum(SBuf *sb, cTValue *o);
 LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putptr(SBuf *sb, const void *v);
 LJ_FUNC SBuf * lj_strfmt_putquoted(SBuf *sb, const char *s, MSize len);
 LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putquotedstr(SBuf *sb, GCstr *str);
+LJ_FUNC SBuf * LJ_FASTCALL lj_strfmt_putquotedbuf(SBuf *sb, SBuf *sb2);
 
 /* Formatted conversions to buffer. */
 LJ_FUNC SBuf *lj_strfmt_putfxint(SBuf *sb, SFormat sf, uint64_t k);
@@ -105,6 +106,7 @@ LJ_FUNC SBuf *lj_strfmt_putfnum(SBuf *sb, SFormat, lua_Number n);
 LJ_FUNC SBuf *lj_strfmt_putfchar(SBuf *sb, SFormat, int32_t c);
 LJ_FUNC SBuf *lj_strfmt_putf(SBuf *sb, SFormat, const char *s, MSize len);
 LJ_FUNC SBuf *lj_strfmt_putfstr(SBuf *sb, SFormat, GCstr *str);
+LJ_FUNC SBuf *lj_strfmt_putfbuf(SBuf *sb, SFormat, SBuf *sb2);
 
 /* Conversions to strings. */
 LJ_FUNC GCstr * LJ_FASTCALL lj_strfmt_int(lua_State *L, int32_t k);

--- a/tests/runtests.bat
+++ b/tests/runtests.bat
@@ -1,0 +1,3 @@
+cd "%~dp0"
+..\src\luajit.exe test.lua
+pause

--- a/tests/runtests.sh
+++ b/tests/runtests.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+cd "${0%/*}"
+../src/luajit ./test.lua

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -779,8 +779,6 @@ collectgarbage("stop")
 skip = {
   setcapacity = true,
   apibuffersupport = true,
-  format = true,
-  rep = true,
   byte = true,
   setbyte = true,
   capacity = true,

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -778,12 +778,6 @@ collectgarbage("stop")
 
 skip = {
   setcapacity = true,
-  write = true,
-  writeln = true,
-  writesub = true,
-  lower = true,
-  upper = true,
-  reverse = true,
   apibuffersupport = true,
   format = true,
   rep = true,

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -747,49 +747,51 @@ function tests.apibuffersupport()
   asserteq(f()(1), 2)
 end
 
+function tmpstr_fold(a1, a2, tail) 
+    local tempstr = a1.."_".. a2
+    return tempstr.."_"..tail
+end
+
+function tmpstr_nofold(a1, a2, tail) 
+    local tempstr = a1.."_".. a2
+    temp2 = tail.."_"..a2 
+    return tempstr.."_"..tail
+end
+
+function tmpstr_cse(a1, a2, tail) 
+    local tempstr = a1.."_".. a2
+    local tempstrdup = a1.."_".. a2
+    return tempstr.."_"..tempstrdup
+end
+
+function tests.fold_tmpbufstr()
+  --test the existing fold for temp buffer only 'bufput_append' LJFOLD(BUFPUT BUFHDR BUFSTR)
+  testjit("foo_1234_5678", tmpstr_fold, "foo", "1234", "5678")
+  testjit("foo_123_456", tmpstr_nofold, "foo", "123", "456")
+  asserteq(temp2,  "456_123")
+  testjit("123_456_123_456", tmpstr_cse, "123", "456")
+end
+
 tracker.start()
 --tracker.setprintevents(true)
 collectgarbage("stop")
 
-function testjit(expected, func, ...)
-
-  local result = func(...)
-
-  if (result ~= expected) then 
-    error("expected \""..tostring(expected).."\" but got \""..tostring(result).."\"", 2)
-  end
-end
-
-testjit2 = function(func, config1, config2)
-
-  local config, expected, shoulderror = config1, config1.expected, config1.shoulderror 
-  local state = 1
-  
-  for i=1, 3 do
-    local status, result
-    
-    if not shoulderror then
-      result = func(unpack(config.args))
-    else
-      status, result = pcall(func, unpack(config.args))
-      
-      if(status) then
-        trerror2("expected call to trigger error but didn't "..tostring(i))
-      end
-    end
-    
-    if not shoulderror and result ~= expected then
-      trerror2("expected '%s' but got '%s' - %s", tostring(expected), tostring(result), (jitted and "JITed") or "Interpreted")
-    end
-    
-    config = config2
-    expected = config2.expected
-    shoulderror = config2.shoulderror 
-  end
-end
-
 skip = {
   setcapacity = true,
+  write = true,
+  writeln = true,
+  writesub = true,
+  lower = true,
+  upper = true,
+  reverse = true,
+  apibuffersupport = true,
+  format = true,
+  rep = true,
+  byte = true,
+  setbyte = true,
+  capacity = true,
+  len = true,
+  setlength = true,
 }
 
 if singletest then

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -764,12 +764,36 @@ function tmpstr_cse(a1, a2, tail)
     return tempstr.."_"..tempstrdup
 end
 
+-- Test folding a BUFSTR with the target being the tmp buffer LJFOLD(BUFPUT any BUFSTR)
+function tmpstrtosbuf_fold(base, a1, a2) 
+    local tempstr = a1.."_".. a2
+    buf:reset()
+    buf:write(base, tempstr)
+    
+    return (buf:tostring())
+end
+
+function tmpstrtosbuf_nofold(base, a1, a2)
+    local temp1 = a1.."_".. a2
+    --second temp buffer use should act as a barrier to the fold
+    temp3 = a2.."_"..a1
+    
+    buf:reset()
+    buf:write(base, temp1)
+    
+    return (buf:tostring())
+end
+
 function tests.fold_tmpbufstr()
   --test the existing fold for temp buffer only 'bufput_append' LJFOLD(BUFPUT BUFHDR BUFSTR)
   testjit("foo_1234_5678", tmpstr_fold, "foo", "1234", "5678")
   testjit("foo_123_456", tmpstr_nofold, "foo", "123", "456")
   asserteq(temp2,  "456_123")
   testjit("123_456_123_456", tmpstr_cse, "123", "456")
+
+  testjit("foo1234_5678", tmpstrtosbuf_fold, "foo", "1234", "5678")
+  testjit("foo123_456", tmpstrtosbuf_nofold, "foo", "123", "456")
+  asserteq(temp3,  "456_123")
 end
 
 tracker.start()

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -1,0 +1,655 @@
+package.path = package.path .. ";../src/?.lua"
+
+local jit = require("jit")
+local jutil = require("jit.util")
+local vmdef = require("jit.vmdef")
+local tracker = require("tracetracker")
+local funcinfo, funcbc, traceinfo = jutil.funcinfo, jutil.funcbc, jutil.traceinfo
+local band = bit.band
+local unpack = unpack
+local buf, buf2
+local testloopcount = 30
+
+local function fmtfunc(func, pc)
+  local fi = funcinfo(func, pc)
+  if fi.loc then
+    return fi.loc
+  elseif fi.ffid then
+    return vmdef.ffnames[fi.ffid]
+  elseif fi.addr then
+    return string.format("C:%x", fi.addr)
+  else
+    return "(?)"
+  end
+end
+
+jit.off(fmtfunc)
+
+local bcnames = {}
+
+for i=1,#vmdef.bcnames/6 do
+  bcnames[i] = string.sub(vmdef.bcnames, i+1, i+6)
+end
+
+
+local expectedlnk = "return"
+
+function trerror(s, a1, ...)
+
+  tracker.print_savedevevents()
+
+  if(a1) then
+    error(string.format(s, a1, ...), 4)
+  else
+    error(s, 4)
+  end
+
+end
+
+local function checktrace(tr, func)
+
+  if tr.abort then
+    trerror("trace aborted with error %s at %s", abort, fmtfunc(tr.stopfunc, tr.stoppc))
+  end
+  
+  local info = traceinfo(tr.traceno)
+  
+  if info.linktype == "stitch" and expectedlnk ~= "stitch" then
+    trerror("trace did not cover full function stitched at %s", fmtfunc(tr.stopfunc, tr.stoppc))
+  end
+  
+  if tr.startfunc ~= func then
+    trerror("trace did not start in tested function. started in %s", fmtfunc(tr.startfunc, tr.startpc))
+  end
+
+  if tr.stopfunc ~= func then
+    trerror("trace did not stop in tested function. stoped in %s", fmtfunc(tr.stopfunc, tr.stoppc))
+  end
+  
+  if info.linktype ~= expectedlnk then
+    trerror("expect trace link '%s but got %s", expectedlnk, info.linktype)
+  end
+end
+
+jit.off(checktrace)
+
+local function begin_jittest(func)
+  jit.flush()
+  jit.on(func, true) --clear any interpreter only function/loop headers that may have been caused by other tests
+  tracker.clear()
+end
+
+function trerror2(s, a1, ...)
+
+  tracker.print_savedevevents()
+
+  if(a1) then
+    error(string.format(s, a1, ...), 3)
+  else
+    error(s, 3)
+  end
+
+end
+
+function testjit(expected, func, ...)
+
+  begin_jittest(func)
+
+  for i=1, testloopcount do
+  
+    local result = func(...)
+
+    if (result ~= expected) then
+      local jitted, anyjited = tracker.isjited(func)
+      tracker.print_savedevevents()
+      trerror2("expected '%s' but got '%s' - %s", tostring(expected), tostring(result), (jitted and "JITed") or "Interpreted")
+    end
+  end
+
+  local traces = tracker.traces()
+  
+  if #traces == 0 then
+    trerror2("no traces were started for test "..expected, 2)
+  end
+  
+  local tr = traces[1]
+
+  checktrace(tr, func)
+
+  if tracker.hasexits() then
+    trerror2("unexpect traces exits "..expected)
+  end
+    
+  if #traces > 1 then
+    trerror2("unexpect extra traces were started for test "..expected)
+  end
+  --trace stop event doesn't provide a pc so would need to save the last pc traced
+  --[[
+  local stopbc = bcnames[band(funcbc(tr.stopfunc, tr.stoppc), 0xff)]
+  
+  if stopbc:find("RET") ~= 1 then
+    error(string.format("trace stoped at unexpected bytecode"), 2)
+  end
+  ]]
+  
+  jit.flush()  
+end
+
+jit.off(testjit)
+
+--FIXME: the side traces that happen for config 2 will always abort because they trace out into this function which has jit turned off
+local function testjit2(func, config1, config2)
+
+  begin_jittest(func)
+  
+  local jitted = false
+  local trcount = 0
+  local config, expected, shoulderror = config1, config1.expected, config1.shoulderror 
+  local state = 1
+  local sidestart = 0
+  
+  for i=1, testloopcount do
+    local status, result
+    
+    if not shoulderror then
+      result = func(unpack(config.args))
+    else
+      status, result = pcall(func, unpack(config.args))
+      
+      if(status) then
+        tracker.print_savedevevents()
+        trerror2("expected call to trigger error but didn't "..tostring(i))
+      end
+    end
+    
+    if state == 2 then
+      if tracker.hasexits() then
+        trerror2("trace exited on first run after being compiled "..expected)
+      end
+      state = 3
+    end
+    
+    local newtraces = tracker.traceattemps() ~= trcount
+    
+    if newtraces then
+      trcount = tracker.traceattemps()
+      jitted, anyjited = tracker.isjited(func)  
+      
+      if state == 1 then
+      --let the trace be executed once before we switch to the next arguments
+        state = 2
+      elseif state == 4 and not tracker.traces()[trcount].abort  then
+        state = 5
+        sidestart = tracker.exitcount()
+        print("side trace compiled ".. tostring(expected))
+      end
+    end
+    
+    if not shoulderror and result ~= expected then
+      tracker.print_savedevevents()
+      error(string.format("expected '%s' but got '%s' - %s", tostring(expected), tostring(result), (jitted and "JITed") or "Interpreted"), 2)
+    end
+    
+    if state == 3 then
+      config = config2
+      expected = config2.expected
+      shoulderror = config2.shoulderror
+      state = 4
+    end
+    
+  end
+  
+  local traces = tracker.traces()
+  
+  if #traces == 0 then
+    trerror2("no traces were started for test "..expected)
+  end
+  
+  local tr = traces[1]
+
+  checktrace(tr, func)
+  
+  if not tracker.hasexits() then
+    trerror2("Expect trace to exit to interpreter")
+  end
+  
+  if sidestart ~= 0 and tracker.exitcount() > sidestart then
+    trerror2("Unexpected exits from side trace")
+  end
+  
+  assert(state >= 4)
+end
+
+jit.off(testjit2)
+
+require("jit.opt").start("hotloop=2")
+--force the loop and function header in testjit to abort and be patched
+local dummyfunc = function() return "" end
+for i=1,30 do
+  pcall(testjit, "", dummyfunc, "")
+end
+
+require("jit.opt").start("hotloop=5")
+
+function reset_write(buf, ...)
+  buf:reset()
+  buf:write(...)
+    
+  return buf
+end
+
+function asserteq(result, expected)
+
+  if (result ~= expected) then 
+    error("expected \""..tostring(expected).."\" but got \""..tostring(result).."\"", 2)
+  end
+
+  return result
+end
+
+
+local tostringobj = setmetatable({}, {
+    __tostring = function(self) 
+        return "tostring_result"
+    end
+})
+
+local tostringerr = setmetatable({}, {
+    __tostring = function() 
+        return error("throwing tostring")
+    end
+})
+
+local tostring_turtle = setmetatable({}, {
+    __tostring = function(self) 
+        return self.turtle
+    end
+})
+
+
+local buf_empty = string.createbuffer()
+local buf_a = string.createbuffer()
+buf_a:write("a")
+local buf_abc = string.createbuffer()
+buf_abc:write("abc")
+
+buf = string.createbuffer()
+buf2 = string.createbuffer()
+
+
+tests = {}
+
+function tests.createbuffer()
+
+  --the internal buffer should always be allocated
+  assert(string.createbuffer():capacity() ~= 0)
+  -- test providing the initial capacity
+  assert(string.createbuffer(512):capacity() >= 512)
+end
+
+local function bufcapacity(buf)
+  return (buf:capacity())
+end
+
+local function bufleft(buf)
+  return buf:capacity()-buf:len()
+end
+
+function tests.capacity()
+  local capacity = buf:capacity()
+  testjit(capacity, bufcapacity, buf)
+  
+  capacity = buf_a:capacity()
+  testjit(capacity-1, bufleft, buf_a)
+end
+
+function tests.setcapacity()
+  reset_write(buf, "foobar")
+  buf:setcapacity(120)
+  asserteq(buf:capacity(), 120)
+  asserteq(buf:tostring(), "foobar")
+  
+  buf:setcapacity(32)
+  asserteq(buf:capacity(), 32)
+  asserteq(buf:tostring(), "foobar")
+  
+  --check clamping to min capacity
+  buf:setcapacity(0)
+  assert(buf:capacity() ~= 0)
+  asserteq(buf:tostring(), "foobar")
+
+  assert(not pcall(buf.setcapacity, buf, 0x7fffff01))
+end
+
+local function bufsize(buf)
+  return (buf:len())
+end
+
+local function bufsizechange(buf, s)
+  local size1 = buf:len()
+  buf:write(s)
+  return buf:len()-size1
+end
+
+function tests.len()
+
+  asserteq(#buf_empty, 0)
+  asserteq(#buf_a, 1)
+  
+  testjit(0, bufsize, buf_empty)
+  testjit(1, bufsize, buf_a)
+  
+  --check buffer pointers are reloaded when getting the size before and after an append to the buffer
+  testjit(3, bufsizechange, buf, "foo")
+end
+
+function tests.setlength()
+  
+  buf:setlength(1)
+  asserteq(buf:len(), 1)
+  
+  buf:setlength(0)
+  asserteq(buf:len(), 0)
+
+  --setting size larger than the buffer should throw an error
+  assert(not pcall(buf.setlength, buf, buf:capacity()+1))
+  assert(not pcall(buf.setlength, buf, -1))
+
+  --check truncating contents in the buffer
+  buf:write("foobar1")
+  asserteq(buf:len(), 7)
+  buf:setlength(6)
+  asserteq(buf:len(), 6)
+  asserteq(buf:tostring(), "foobar")
+  
+  --Check setting size to capacity
+  local minsize = buf:capacity()
+  buf:setlength(buf:capacity())
+  buf:write("a")
+  assert(buf:len() > minsize)
+  
+  buf:setlength(6)
+  asserteq(buf:tostring(), "foobar")
+end
+
+function tests.reserve()
+  local capacity = buf:capacity()
+  
+  buf:setlength(buf:capacity()-1)
+  
+  buf:reserve(0)
+  asserteq(buf:capacity(), capacity)
+  
+  buf:reserve(1)
+  asserteq(buf:capacity(), capacity)
+  
+  buf:reserve(2)
+  assert(buf:capacity() > capacity)
+  
+  assert(not pcall(buf.reserve, buf, -1))
+end
+
+function tests.equals()
+
+  assert(buf_a:equals("a"))
+  assert(not buf_a:equals("b"))
+  assert(not buf_a:equals("aa"))
+  
+  assert(buf_empty:equals(""))
+  assert(not buf_empty:equals("a"))
+  
+  --compare buffer to buffer
+  reset_write(buf, "foo")
+  assert(buf:equals(buf))
+  assert(buf_empty:equals(buf_empty))
+  assert(not buf:equals(buf_empty))
+  
+  reset_write(buf2, "foo")
+  assert(buf:equals(buf2))
+end
+
+local function getbyte(buf, i)
+  return (buf:byte(i))
+end
+
+function tests.byte()
+
+  local a = string.byte("a")
+  local b = string.byte("b")
+  local c = string.byte("c")
+  
+  assert(not pcall(getbyte, buf_a, 0))
+  assert(not pcall(getbyte, buf_empty, 0))
+  assert(not pcall(getbyte, buf_empty, 1))
+  assert(not pcall(getbyte, buf_empty, -1))
+  
+  testjit(a, getbyte, buf_a, 1)
+  testjit(b, getbyte, buf_abc, 2)
+  testjit(a, getbyte, buf_a, -1)
+  testjit(a, getbyte, buf_abc, -3)
+  
+  --check guard for index changing from negative to positive 
+  testjit2(getbyte, {args = {buf_abc, -3}, expected = a}, 
+                    {args = {buf_abc, 2}, expected = b})
+
+  local start = {args = {buf_a, 1}, expected = a}
+  testjit2(getbyte, start, {args = {buf_abc, -3}, expected = a})
+  testjit2(getbyte, start, {args = {buf_abc, -2}, expected = b})
+  testjit2(getbyte, start, {args = {buf_abc, -1}, expected = c})
+  
+  testjit2(getbyte, start, {args = {buf_empty, 0}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_abc, 0}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_a, 0}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_a, 2}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_a, -2}, shoulderror = true})
+
+  --check when the buffer changed to empty
+  start = {args = {buf_a, -1}, expected = a}
+  testjit2(getbyte, start, {args = {buf_empty, 0}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_empty, 1}, shoulderror = true})
+  testjit2(getbyte, start, {args = {buf_empty, -1}, shoulderror = true})
+end
+--tracker.setprintevents(true)
+--singletest = tests.byte
+
+local function fixslash(buf, path)
+
+  local slash = string.byte("\\")
+
+  buf:reset()
+  buf:write(path)
+  
+  for i=1,#buf do
+    if buf:byte(i) == slash then
+      buf:setbyte(i, "/")
+    end
+  end
+  
+  return (buf:tostring())
+end
+
+local function setbyte(buf, i, b)
+  buf:setbyte(i, b)
+  return (buf:tostring())
+end
+
+function tests.setbyte()
+  reset_write(buf, "a")
+
+  asserteq(setbyte(buf, 1, "b"), "b")
+  asserteq(setbyte(buf, -1, "c"), "c")
+  asserteq(setbyte(buf, 1, 97), "a")
+  
+  --check error for index out of range
+  reset_write(buf, "a")
+  assert(not pcall(setbyte, buf, 2, "b"))
+  assert(buf:equals("a"))
+  
+  assert(not pcall(setbyte, -2, "b"))
+  assert(buf:equals("a"))
+  
+  --TODO: refactor jittest for this
+  --testjit("a/bar/c/d/e/foo/a/b/c/d/e/f", fixslash, buf, "a\\bar\\c\\d\\e\\foo\\a\\b\\c\\d\\e\\f")
+  asserteq("a/bar/c/d/e/foo/a/b/c/d/e/f", fixslash(buf, "a\\bar\\c\\d\\e\\foo\\a\\b\\c\\d\\e\\f"))
+end
+
+function testwrite(a1, a2, a3, a4)
+  buf:reset()
+
+  if(a2 == nil) then
+    buf:write(a1)
+  elseif(a3 == nil) then
+    buf:write(a1, a2)
+  elseif(a4 == nil) then
+    buf:write(a1, a2, a3)
+  else 
+    buf:write(a1, a2, a3, a4)
+  end
+ 
+  return (buf:tostring())
+end
+
+function tests.write()
+  asserteq(testwrite("a"), "a")
+  asserteq(testwrite(""), "")
+
+  testjit("bar", testwrite, "bar")
+  testjit("1234567890", testwrite, 1234567890)
+  testjit("12345.9375", testwrite, 12345.9375)
+  testjit("foo2bar", testwrite, "foo", 2, "bar")
+  testjit("true1false", testwrite, true, 1, false)
+  
+  asserteq(testwrite(tostringobj), "tostring_result")
+  
+  --Make sure the buffer is unmodifed if an error is thrown
+  reset_write(buf, "foo")
+  local status, err = pcall(function(buff, s, tostr) 
+    buff:write(s, tostr)
+  end, buf, "end", tostringerr)
+  
+  assert(not status and err == "throwing tostring")
+  --buffer is not reset to starting state if an error is thrown during a write/format call
+  asserteq(buf:tostring() , "fooend")
+  
+  --appending one buff to another
+  reset_write(buf2, "buftobuf")
+  testjit("foobuftobuf", testwrite, "foo", buf2)
+end
+
+local function testwriteln(a1)
+    buf:reset()
+    
+    if(a1 == nil) then
+      buf:writeln()
+    else
+      buf:writeln(a1)
+    end
+    
+    return (buf:tostring())
+end
+
+function tests.writeln()
+  testjit("\n", testwriteln)
+  testjit("foo\n", testwriteln, "foo")
+end
+
+local function testwritesub(base, s, ofs, len)
+  buf:reset()
+  buf:write(base)
+    
+  if(len == nil) then
+    buf:writesub(s, ofs)
+  else
+    buf:writesub(s, ofs, len)
+  end
+
+  return (buf:tostring())
+end
+
+function tests.writesub()
+  --test writing a sub string
+  testjit("n1234567", testwritesub, "n", "01234567",  2)
+  testjit("n67",      testwritesub, "n", "01234567", -2)
+  testjit("n12345",   testwritesub, "n", "01234567",  2, -3) 
+
+  ----check overflow clamping
+  testjit("n1234567",  testwritesub, "n", "01234567",   2, 20)
+  testjit("n01234567", testwritesub, "n", "01234567", -20, 8)
+  
+  --test writing a sub string where the source is another buffer
+  reset_write(buf2, "01234567")
+  testjit("n1234567", testwritesub, "n", buf2,  2)
+  testjit("n67",      testwritesub, "n", buf2, -2)
+  testjit("n12345",   testwritesub, "n", buf2,  2, -3)
+end
+
+tracker.start()
+--tracker.setprintevents(true)
+collectgarbage("stop")
+
+function testjit(expected, func, ...)
+
+  local result = func(...)
+
+  if (result ~= expected) then 
+    error("expected \""..tostring(expected).."\" but got \""..tostring(result).."\"", 2)
+  end
+end
+
+testjit2 = function(func, config1, config2)
+
+  local config, expected, shoulderror = config1, config1.expected, config1.shoulderror 
+  local state = 1
+  
+  for i=1, 3 do
+    local status, result
+    
+    if not shoulderror then
+      result = func(unpack(config.args))
+    else
+      status, result = pcall(func, unpack(config.args))
+      
+      if(status) then
+        trerror2("expected call to trigger error but didn't "..tostring(i))
+      end
+    end
+    
+    if not shoulderror and result ~= expected then
+      trerror2("expected '%s' but got '%s' - %s", tostring(expected), tostring(result), (jitted and "JITed") or "Interpreted")
+    end
+    
+    config = config2
+    expected = config2.expected
+    shoulderror = config2.shoulderror 
+  end
+end
+
+skip = {
+  setcapacity = true,
+}
+
+if singletest then
+  print("Running: single test")
+  singletest()
+else
+  --should really order these by line
+  for name,func in pairs(tests) do
+    if not skip[name] then
+      print("Running: "..name)
+      func()
+    else
+      print("Skipping: "..name)
+    end
+   
+  end
+end
+
+print("tests past")
+
+
+
+
+
+
+
+

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -583,6 +583,68 @@ function tests.writesub()
   testjit("n12345",   testwritesub, "n", buf2,  2, -3)
 end
 
+function testformat(a1, a2, a3, a4)
+  buf:reset()
+  
+  if(a2 == nil) then
+    buf:format(a1)
+  elseif(a3 == nil) then
+    buf:format(a1, a2)
+  elseif(a4 == nil) then
+    buf:format(a1, a2, a3)
+  else
+    buf:format(a1, a2, a3, a4)
+  end
+    
+  return (buf:tostring())
+end
+
+function tests.format()
+  testjit("foo", testformat, "foo")
+  testjit("", testformat, "")
+  testjit("bar", testformat, "%s", "bar")
+  testjit("_bar_", testformat, "_%s_", "bar")  
+  testjit("120, foo, 123.75", testformat, "%d, %s, %g", 120, "foo", 123.75)
+
+  testjit("ba", testformat, "%.2s", "bar")
+  testjit("foo _  bar", testformat, "%-4s_%5s", "foo", "bar") 
+  testjit("\"\\0bar\\0\"", testformat, "%q", "\0bar\0")
+  
+  --check __tostring is called on objects
+  asserteq(testformat("%s %s", "foo", tostringobj), "foo tostring_result")
+end
+
+local function testrep(s, rep, sep)
+  buf:reset()
+  
+  if(sep == nil) then
+    buf:rep(s, rep)
+  else
+    buf:rep(s, rep, sep)
+  end
+  
+  return (buf:tostring())
+end
+
+local function teststringrep(s, rep, sep)
+
+  if(sep == nil) then
+    return (string.rep(s, rep))
+  else
+    return (string.rep(s, rep, sep))
+  end
+end
+
+function tests.rep()
+  testjit("aaa", testrep, "a", 3)
+  testjit("a,a,a", testrep, "a", 3, ",")
+  testjit("a", testrep, "a", 1, ",")
+  --check string.rep still works
+  testjit("aaa", teststringrep, "a", 3)
+  testjit("a,a,a", teststringrep, "a", 3, ",")
+  testjit("a", teststringrep, "a", 1, ",")
+end
+
 tracker.start()
 --tracker.setprintevents(true)
 collectgarbage("stop")

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -718,7 +718,7 @@ function tests.apibuffersupport()
   testjit(true, iowrite, file, buf, " ")
   
   buf2:reset()
-  buf2:rep("buff test", 1, " ")
+  buf2:rep("buff test", testloopcount, " ")
   buf2:write(" ") 
   file:seek("set", 0)
   asserteq(file:read("*a"), buf2:tostring())
@@ -778,11 +778,6 @@ collectgarbage("stop")
 
 skip = {
   setcapacity = true,
-  apibuffersupport = true,
-  byte = true,
-  setbyte = true,
-  capacity = true,
-  len = true,
   setlength = true,
 }
 

--- a/tests/test.lua
+++ b/tests/test.lua
@@ -645,6 +645,50 @@ function tests.rep()
   testjit("a", teststringrep, "a", 1, ",")
 end
 
+local function lower(buf, s)
+  buf:reset()
+  buf:write(s)
+  buf:lower()
+  
+  return (buf:tostring()) 
+end
+
+function tests.lower()
+  testjit("bar", lower, buf, "BaR")
+  testjit(" ", lower, buf, " ")
+  testjit("", lower, buf, "")
+end
+
+local function upper(buf, s)
+  buf:reset()
+  buf:write(s)
+  buf:upper()
+  
+  return (buf:tostring()) 
+end
+
+function tests.upper()
+  testjit("BAR", upper, buf, "bAr")
+  testjit(" ", upper, buf, " ")
+  testjit("", upper, buf, "")
+end
+
+local function reverse(buf, s)
+  buf:reset()
+  buf:write(s)
+  buf:reverse()
+  
+  return (buf:tostring()) 
+end
+
+function tests.reverse()
+  testjit("a", reverse, buf, "a")
+  testjit("", upper, buf, "")
+  testjit("21", reverse, buf, "12")
+  testjit("321", reverse, buf, "123")
+  testjit("dcba", reverse, buf, "abcd")
+end
+
 tracker.start()
 --tracker.setprintevents(true)
 collectgarbage("stop")

--- a/tests/tracetracker.lua
+++ b/tests/tracetracker.lua
@@ -1,0 +1,202 @@
+local jit = require("jit")
+local jutil = require("jit.util")
+local vmdef = require("jit.vmdef")
+local funcinfo, funcbc, traceinfo = jutil.funcinfo, jutil.funcbc, jutil.traceinfo
+local band = bit.band
+
+local lib 
+local traces, texits = {}, {}
+
+local printevents = false 
+
+local function fmtfunc(func, pc)
+  local fi = funcinfo(func, pc)
+  if fi.loc then
+    return fi.loc
+  elseif fi.ffid then
+    return vmdef.ffnames[fi.ffid]
+  elseif fi.addr then
+    return string.format("C:%x", fi.addr)
+  else
+    return "(?)"
+  end
+end
+
+-- Format trace error message.
+local function fmterr(err, info)
+  if type(err) == "number" then
+    if type(info) == "function" then info = fmtfunc(info) end
+    err = string.format(vmdef.traceerr[err], info)
+  end
+  return err
+end
+
+
+local function print_trevent(tr, printall)
+  
+  if printall or not tr.stopfunc then
+    print(string.format("\n[TRACE(%d) start at %s]", tr.traceno, fmtfunc(tr.startfunc, tr.startpc)))
+  end
+
+  if tr.abort then
+    print(string.format("[TRACE(%d) abort at %s, error = %s]", tr.traceno, fmtfunc(tr.stopfunc, tr.stoppc), tr.abort))
+  elseif tr.stopfunc then
+    print(string.format("[TRACE(%d) stop at %s]", tr.traceno, fmtfunc(tr.stopfunc, tr.stoppc)))
+  end
+end
+
+local function trace_event(what, tr, func, pc, otr, oex)
+
+  local trace
+
+  if what == "flush" then
+    return
+  end
+  
+  if what == "start" then
+    trace = {
+      traceno = tr,
+      startfunc = func,
+      startpc = pc,
+    }
+    traces[#traces+1] = trace
+  elseif what == "abort" or what == "stop" then
+    trace = traces[#traces]
+    assert(trace and trace.traceno == tr)
+    
+    trace.stopfunc = func
+    trace.stoppc = pc
+    
+    if what == "abort" then
+      lib.aborts = lib.aborts+1
+      trace.abort = fmterr(otr, oex)
+    end
+  else
+    assert(false, what)
+  end
+  
+  if printevents then
+    print_trevent(trace)
+  end
+end
+
+local function trace_exit(tr, ex, ngpr, nfpr, ...)
+  texits[#texits+1] = {
+    tr = tr,
+    exitno = ex,
+    order = #traces
+  }
+  
+  if printevents then
+    print("---- TRACE ", tr, " exit ", ex)
+  end
+end
+
+local function isjited(func, starti)
+
+  local hasany = false
+
+  starti = starti or 1
+  
+  for i=starti,#traces do
+  
+    local tr = traces[i]
+  
+    if not tr.abort then
+      hasany = true
+      if tr.startfunc == func or tr.stopfunc == func then
+        return i, true
+      end
+    end
+  end
+  
+  return false,hasany
+end
+
+function hastraces(optfunc, starti)
+
+  if not optfunc then
+    return traces[1] ~= nil
+  end
+
+  starti = starti or 1
+  
+  for i=starti,#traces do
+  
+    if tr.startfunc == func or tr.stopfunc == func then
+      return i, true
+    end  
+    if not tr.abort then
+      hasany = true
+    end
+  end
+end
+
+local active = false
+
+local function start()
+  if not active then
+    active = true
+    jit.attach(trace_event, "trace")
+    jit.attach(trace_exit, "texit")
+  end
+end
+
+local function stop()
+  if active then
+    active = false
+    jit.attach(trace_event)
+    jit.attach(trace_exit)
+    --jit.attach(dump_trace)
+  end
+end
+
+local function clear()
+  traces = {}
+  texits = {}
+  lib.aborts = 0
+end
+
+local function print_savedevevents()
+
+  local nextexit = texits[1] and texits[1].order
+  local exi = 1
+
+  for i,tr in ipairs(traces) do
+    print_trevent(tr, true)
+    
+    if nextexit and i >= nextexit then
+      for i=exi,#texits do
+        
+        local exit = texits[i]
+        
+        if exit.order > i then 
+          exi = i
+          break
+        end
+      
+        print("---- TRACE ", exit.tr, " exit ", exit.exitno)
+      end
+    end
+    
+  end
+end
+
+lib = {
+  start = start,
+  stop = stop,
+  clear = clear,
+  
+  isjited = isjited,
+  hasexits = function() return texits[1] ~= nil end,
+  setprintevents = function(enabled) printevents = enabled end,
+  traces = function() return traces end,
+  exitcount = function() return #texits end,
+  traceattemps = function() return #traces end,
+  print_savedevevents = print_savedevevents,
+  aborts = 0,
+}
+
+jit.off(true, true)
+
+return lib


### PR DESCRIPTION
The string buffers are implemented as suggested here #14 as a new built-in userdata with an unmodified SBuf struct as the userdata payload which can be created with **string.createbuffer([initcap])**. The current API is mostly write based at the moment but it would be useful to allow reading data into the buffer like from file.read which could be strong case to add string read API like find/match. A few existing functions have been given support to be passed string buffers in-place of strings **loadstring**, **file.write/print**, **string.format** for %s/%q arguments.

I've broken the changes out into several commits based on related API changes/additions so they're easier to follow. The tests(tests/test.lua) should pass for each individual commit and check for successful traces where applicable as well as there are no guards failing with unchanged arguments.
##### Current issues

If you some buffer api tries to grow the buffer past LJ_MAX_BUF you will get a lua_panic if its in jited code
##### IR changes
- Added IR_BUFTL mostly works like IR_USE to keep buffer write operations alive as the tail of the buf chain in place of IR_BUFSTR for each write like API call but later on it could be used to allow folding to separate write like calls with constant values together.
- BUFHDR has 2 new modes MODIFY used for anything that directly loads the buffer pointers in IR  and RESIZE that will be used for **setlength** and **reserve**. There is also a flag bit to distinguish string buffer headers from temp buffer headers.
- IR_BUFHDR has a new fold rule to CSE IR_BUFHDR for the same buffer where the mode is IRBUFHDR_MODIFY in both them and no other IR_BUFHDR in-between with a different mode that isn't the temp buffer.
##### API
- **boolean equals(string/stringbuffer)** directly compares the bytes of the string buffer upto its current length with the string/string buffer passed in.
- **string tostring()** Copies the buffer to a new lua string.
- **int len()** Gets the current length of the string buffer, length # operator also works.
- **setlength(int length,[fillvalue])** Sets the length of the buffer(max value is current capacity) filling any extra space with the fill value provided(defaulted to 0) or 
  it can be left uninitialized if false is passed in and LuaJIT is built with ffi enabled.
- **reset()** Resets the buffers length back to 0 but leaving its capacity unchanged.
- **int capacity()** Returns the current capacity of the buffer.
- **reserve(int more)** Ensure the buffer has the requested space left causing it to reallocate to a larger capacity if needed.
- **int byte(int n)** Returns the n-th byte(one based offset) or negative offset from the end of the string buffer based on length. 
- **setbyte(int n, [int or string] byte)** Sets the i-th byte(one based offset) or a negative offset from the end of the buffer. n has tobe smaller than the current buffer length. A string can be passed in-place a of a number and it first byte will be used instead.
- **write(...)** Writes the list of values passed into the buffer invoking there meta __tostring for non primitive values like tables/userdata. string buffers passed in are directly copied instead of tostring being called on them.
- **writeln(...)** Same as write but automatically appends a \n newline after writing the values passed in.
- **writesub(string/stringbuffer, int start[, int end])** Writes a substring of either a string or string buffer to the buffer, start/end works like string.sub.
- **format(string s, ...)** Writes a formatted string to the buffer arguments works the same as string.format but can also take string buffers in place of strings for %s/q format entries
- **rep(string s, rep[, string sep])** works the same as string.rep but writing the result to the buffer 
- **lower()** In-place string.lower.
- **upper()** In-place string.upper.
- **reverse()** In-place string.reverse.

#### Future ideas:
- Bounds check elimination for byte/setbyte in loops like that have no conflicting buffer append/resize/reset operations in a loop like this.
  `for i=1,#buff do
  buf:byte(i)
  end`
- Allocation sinking for IR_BUFSTR from the temp buffer that been kept alive by a stack slot but is never used because the temp buffer fold rule into string buffers.
- Cloning a temp buffer IR chain into string buffer with the right heuristics but it still could be a performance loss if the result of the temp buffer IR_BUFSTR is still used somewhere else
- A WriteEscaped API that is more useful than %q maybe even using SSE 4.1 string machine instructions when available.
- A way to lookup a string key in a table with using a string buffer
- Add string buffer support to lj_lib_checkstr\lj_ir_tostr.
  ##### More string buffer API support
  - The rest of the string lib.
  - ffi.memcpy both src and dst
  - file.read(mode[, stringbuffer])
