### PR TITLE
Disable os.execute() when building for iOS >= 8.0.

### DIFF
--- a/src/lib_os.c
+++ b/src/lib_os.c
@@ -39,7 +39,7 @@
 
 LJLIB_CF(os_execute)
 {
-#if LJ_TARGET_CONSOLE
+#if LJ_NO_SYSTEM
 #if LJ_52
   errno = ENOSYS;
   return luaL_fileresult(L, 0, NULL);

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -498,7 +498,7 @@
 #if defined(__symbian__) || LJ_TARGET_WINDOWS
 #define LUAJIT_NO_EXP2
 #endif
-#if LJ_TARGET_CONSOLE || (LJ_TARGET_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0)
+#if LJ_TARGET_CONSOLE || (LJ_TARGET_IOS && __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_8_0)
 /* system() is deprecated starting from iOS 8.0 */
 #define LJ_NO_SYSTEM		1
 #endif

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -498,6 +498,10 @@
 #if defined(__symbian__) || LJ_TARGET_WINDOWS
 #define LUAJIT_NO_EXP2
 #endif
+#if LJ_TARGET_CONSOLE || (LJ_TARGET_IOS && __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_8_0)
+/* system() is deprecated starting from iOS 8.0 */
+#define LJ_NO_SYSTEM		1
+#endif
 
 #if defined(LUAJIT_NO_UNWIND) || defined(__symbian__) || LJ_TARGET_IOS || LJ_TARGET_PS3 || LJ_TARGET_PS4
 #define LJ_NO_UNWIND		1


### PR DESCRIPTION
This fixes the following deprecation warning when building for iOS

```
lib_os.c:52:14: warning: 'system' is deprecated: first deprecated in iOS 8.0 -
      Use posix_spawn APIs instead. [-Wdeprecated-declarations]
  int stat = system(cmd);
             ^
/Applications/Xcode.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS8.4.sdk/usr/include/stdlib.h:177:6: note:
      'system' has been explicitly marked deprecated here
int      system(const char *) __DARWIN_ALIAS_C(system) __OSX_AVAILABLE_B...
         ^
1 warning generated.
```

Fixes issue #3.
