### PR TITLE
On Mac OS switch default compiler from gcc to clang. 

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -453,13 +453,18 @@ much slower than the JIT compiler. Please complain to Apple, not me.
 Or use Android. :-p
 </p>
 <pre class="code">
-IXCODE=`xcode-select -print-path`
-ISDK=$IXCODE/Platforms/iPhoneOS.platform/Developer
-ISDKVER=iPhoneOS6.0.sdk
-ISDKP=$ISDK/usr/bin/
-ISDKF="-arch armv7 -isysroot $ISDK/SDKs/$ISDKVER"
-make HOST_CC="gcc -m32 -arch i386" CROSS=$ISDKP TARGET_FLAGS="$ISDKF" \
-     TARGET_SYS=iOS
+# Cross-compile for a 32bit ARM.
+ISDKP=`xcrun --sdk iphoneos --show-sdk-path`
+ICC=`xcrun --sdk iphoneos --find clang`
+ISDKF="-arch armv7 -isysroot $ISDKP"
+make HOST_CC="clang -m32 -arch i386" CROSS="$(dirname $ICC)/" \
+     TARGET_FLAGS="$ISDKF" TARGET_SYS=iOS
+
+# Cross-compile for an ARM64.
+ISDKP=`xcrun --sdk iphoneos --show-sdk-path`
+ICC=`xcrun --sdk iphoneos --find clang`
+ISDKF="-arch arm64 -isysroot $ISDKP"
+make CROSS="$(dirname $ICC)/" TARGET_FLAGS="$ISDKF" TARGET_SYS=iOS
 </pre>
 
 <h3 id="consoles">Cross-compiling for consoles</h3>

--- a/src/Makefile
+++ b/src/Makefile
@@ -17,6 +17,33 @@ ABIVER=  5.1
 NODOTABIVER= 51
 
 ##############################################################################
+################################  HOST SYSTEM  ###############################
+##############################################################################
+
+ifeq (Windows,$(findstring Windows,$(OS))$(MSYSTEM)$(TERM))
+  HOST_SYS= Windows
+  HOST_RM= del
+else
+  HOST_SYS:= $(shell uname -s)
+  ifneq (,$(findstring MINGW,$(HOST_SYS)))
+    HOST_SYS= Windows
+    HOST_MSYS= mingw
+  endif
+  ifneq (,$(findstring CYGWIN,$(HOST_SYS)))
+    HOST_SYS= Windows
+    HOST_MSYS= cygwin
+  endif
+endif
+
+# We default to GCC on all platforms except Mac OS where the default compiler is
+# clang starting with XCode 5.0.
+ifneq (Darwin,$(HOST_SYS))
+  DEFAULT_CC= gcc
+else
+  DEFAULT_CC= clang
+endif
+
+##############################################################################
 #############################  COMPILER OPTIONS  #############################
 ##############################################################################
 # These options mainly affect the speed of the JIT compiler itself, not the
@@ -25,10 +52,10 @@ NODOTABIVER= 51
 # with "make clean", followed by "make" if you change any options.
 #
 # LuaJIT builds as a native 32 or 64 bit binary by default.
-CC= gcc
+CC= $(DEFAULT_CC)
 #
 # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
-#CC= gcc -m32
+# CC= $(DEFAULT_CC) -m32
 #
 # Since the assembler part does NOT maintain a frame pointer, it's pointless
 # to slow down the C part by not omitting it. Debugging, tracebacks and
@@ -268,23 +295,8 @@ ifneq (,$(LMULTILIB))
 endif
 
 ##############################################################################
-# System detection.
+# Target system features.
 ##############################################################################
-
-ifeq (Windows,$(findstring Windows,$(OS))$(MSYSTEM)$(TERM))
-  HOST_SYS= Windows
-  HOST_RM= del
-else
-  HOST_SYS:= $(shell uname -s)
-  ifneq (,$(findstring MINGW,$(HOST_SYS)))
-    HOST_SYS= Windows
-    HOST_MSYS= mingw
-  endif
-  ifneq (,$(findstring CYGWIN,$(HOST_SYS)))
-    HOST_SYS= Windows
-    HOST_MSYS= cygwin
-  endif
-endif
 
 TARGET_SYS?= $(HOST_SYS)
 ifeq (Windows,$(TARGET_SYS))

--- a/src/Makefile
+++ b/src/Makefile
@@ -55,7 +55,7 @@ endif
 CC= $(DEFAULT_CC)
 #
 # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
-# CC= $(DEFAULT_CC) -m32
+#CC= $(DEFAULT_CC) -m32
 #
 # Since the assembler part does NOT maintain a frame pointer, it's pointless
 # to slow down the C part by not omitting it. Debugging, tracebacks and


### PR DESCRIPTION
XCode has been shipping with clang since XCode 5.0 released in September 2013.

Change iOS cross compilation instructions to rely on `xcrun` to locate compiler instead of hard-coding the path and SDK version. Provide instructions for cross-compilation to ARM64.

Fixes issue #1.
Fixes issue #4.

[There are different ways to write the command line with the recent XCode because cross-compiler and host-compiler are actually the same compiler, so you don't even need `CROSS` - but I opted to use it to highlight that it's a cross-compilation. Unrelated question: while testing this I discovered that one needs to actually set `TARGET_DYLIBPATH` to something meaningful. Should the doc reflect this? Right now `TARGET_DYLIBPATH` is set to `/usr/local/lib/libluajit-5.1.2.dylib` by default which is not a path suitable for iOS.]