### PR TITLE
Fix pairs/ipairs recording.

### DIFF
--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -435,11 +435,12 @@ static void LJ_FASTCALL recff_ipairs_aux(jit_State *J, RecordFFData *rd)
 
 static void LJ_FASTCALL recff_xpairs(jit_State *J, RecordFFData *rd)
 {
-  if (!(LJ_52 && recff_metacall(J, rd, MM_ipairs))) {
-    TRef tab = J->base[0];
-    if (tref_istab(tab)) {
+  TRef val = J->base[0];
+  if (!((LJ_52 || (LJ_HASFFI && tref_iscdata(val))) &&
+        recff_metacall(J, rd, rd->data ? MM_ipairs : MM_pairs))) {
+    if (tref_istab(val)) {
       J->base[0] = lj_ir_kfunc(J, funcV(&J->fn->c.upvalue[0]));
-      J->base[1] = tab;
+      J->base[1] = val;
       J->base[2] = rd->data ? lj_ir_kint(J, 0) : TREF_NIL;
       rd->nres = 3;
     }  /* else: Interpreter will throw. */


### PR DESCRIPTION
There were two bugs here: 

* cdata metamethods were not respected: an assumption that `ipairs(cd)` would throw is incorrect if `cd` has `__ipairs`. This lead to state divergence between the recorder and the interpreter;
* wrong metamethod was called when recording `pairs`;

Fixes issue #103.
