### PR TITLE
Support valgrind errors in str_fastcmp also when it is not inlined

### DIFF
--- a/src/lj.supp
+++ b/src/lj.supp
@@ -24,3 +24,18 @@
    Memcheck:Cond
    fun:lj_str_new
 }
+{
+   Optimized string compare
+   Memcheck:Addr4
+   fun:str_fastcmp
+}
+{
+   Optimized string compare
+   Memcheck:Addr1
+   fun:str_fastcmp
+}
+{
+   Optimized string compare
+   Memcheck:Cond
+   fun:str_fastcmp
+}


### PR DESCRIPTION
In debug mode `str_fastcmp` will not be inlined and thus be visible to valgrind. This patch adds another three suppressions to cover this fact.