### PR TITLE
Fix vm_growstack_v in vm_x64.dasc.

### DIFF
--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -531,7 +531,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  jmp >2
   |
   |->vm_growstack_v:			// Grow stack for vararg Lua function.
-  |  sub RD, 8
+  |  sub RD, 16  // Drop two-slot frame info.
   |  jmp >1
   |
   |->vm_growstack_f:			// Grow stack for fixarg Lua function.


### PR DESCRIPTION
It was dropping only half of the two-slot frame info before
growing the stack and retrying the call.

The following test case

```lua
local function foo(depth, ...)
  local vals = {...}

  for i = 1, #vals do
    if type(vals[i]) ~= "number" then
      error(string.format("at depth %d got value %s at slot %d of %d",
                           depth, vals[i], i, #vals))
    end
  end

  if depth > 1000 then 
    -- Stuff seems to work :)
    return
  end

  foo(depth + 1, ...)
end

foo(0, 1, 2, 3, 4, 5, 6, 7, 8)
print("OK")
```

would break with an error

```
$ make XCFLAGS="-DLUAJIT_ENABLE_GC64" -j40
$ src/luajit test.lua
src/luajit: test.lua:7: at depth 1 got value function: 0x7f5d56eaa288 at slot 9 of 9
```

This happens because `BC_IFUNCV` first creates the frame then checks if there is enough space to copy fixargs. If there is no space it goes into `vm_growstack_v` to grow the stack and `vm_growstack_v` is supposed to drop the frame, before growing the stack but it drops only half of it. Function is left over and is treated as yet another vararg on retry.