### PR TITLE
SPLIT should pass through the hiword when droping 64/64 CONV

### DIFF
--- a/src/lj_opt_split.c
+++ b/src/lj_opt_split.c
@@ -472,6 +472,7 @@ static void split_ir(jit_State *J)
 #endif
 	else if (st == IRT_I64 || st == IRT_U64) {  /* 64/64 bit cast. */
 	  /* Drop cast, since assembler doesn't care. */
+	  hi = hiref;  /* Pass through hiword. */
 	  goto fwdlo;
 	} else if ((ir->op2 & IRCONV_SEXT)) {  /* Sign-extend to 64 bit. */
 	  IRRef k31 = lj_ir_kint(J, 31);


### PR DESCRIPTION
This fixes issue #112