### PR TITLE
DynASM/x64: Full VREG support.

### DIFF
--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -170,7 +170,7 @@ void dasm_put(Dst_DECL, int start, ...)
   dasm_State *D = Dst_REF;
   dasm_ActList p = D->actionlist + start;
   dasm_Section *sec = D->section;
-  int pos = sec->pos, ofs = sec->ofs, mrm = 4;
+  int pos = sec->pos, ofs = sec->ofs, mrm = -1;
   int *b;
 
   if (pos >= sec->epos) {
@@ -193,7 +193,7 @@ void dasm_put(Dst_DECL, int start, ...)
       b[pos++] = n;
       switch (action) {
       case DASM_DISP:
-	if (n == 0) { if ((mrm&7) == 4) mrm = p[-2]; if ((mrm&7) != 5) break; }
+	if (n == 0) { if (mrm < 0) mrm = p[-2]; if ((mrm&7) != 5) break; }
       case DASM_IMM_DB: if (((n+128)&-256) == 0) goto ob;
       case DASM_REL_A: /* Assumes ptrdiff_t is int. !x64 */
       case DASM_IMM_D: ofs += 4; break;
@@ -203,10 +203,17 @@ void dasm_put(Dst_DECL, int start, ...)
       case DASM_IMM_W: CK((n&-65536) == 0, RANGE_I); ofs += 2; break;
       case DASM_SPACE: p++; ofs += n; break;
       case DASM_SETLABEL: b[pos-2] = -0x40000000; break;  /* Neg. label ofs. */
-      case DASM_VREG: CK((n&-8) == 0 && (n != 4 || (*p&1) == 0), RANGE_VREG);
-	if (*p++ == 1 && *p == DASM_DISP) mrm = n; continue;
+      case DASM_VREG: CK((n&-16) == 0 && (n != 4 || (*p>>5) != 2), RANGE_VREG);
+	if (*p < 0x40 && p[1] == DASM_DISP) mrm = n;
+	if (*p < 0x20 && (n&7) == 4) ++ofs;
+	switch ((*p++>>3)&3) {
+	case 3: n |= b[pos-3];
+	case 2: n |= b[pos-2];
+	case 1: if(n <= 7) b[pos-1] |= 0x10, --ofs;
+	}
+	continue;
       }
-      mrm = 4;
+      mrm = -1;
     } else {
       int *pl, n;
       switch (action) {
@@ -393,7 +400,19 @@ int dasm_encode(Dst_DECL, void *buffer)
 	case DASM_IMM_W: dasmw(n); break;
 	case DASM_VREG: {
 	  int t = *p++;
-	  if (t >= 5) n <<= 4; else if (t >= 2) n <<= 3;
+	  unsigned char* ex = cp - (t&7);
+	  if ((n & 8) && (t < 0xa0)) {
+	    if (*ex & 0x80) ex[1] ^= 0x20<<(t>>6); else *ex ^= 1<<(t>>6);
+	    n &= 7;
+	  } else if (n & 0x10) {
+	    if (*ex & 0x80) *ex = 0xc5, ex[1] = (ex[1] & 0x80) | ex[2], ex += 2;
+	    while (++ex < cp) ex[-1] = *ex;
+	    if (mark) --mark;
+	    --cp; n &= 7;
+	  }
+	  if (t >= 0xc0) n <<= 4;
+	  else if (t >= 0x40) n <<= 3;
+	  else if (n == 4 && t < 0x20) cp[-1] ^= n, *cp++ = 0x20;
 	  cp[-1] ^= n;
 	  break;
 	}

--- a/dynasm/dasm_x86.lua
+++ b/dynasm/dasm_x86.lua
@@ -41,7 +41,7 @@ local action_names = {
   -- int arg, 1 buffer pos:
   "DISP",  "IMM_S", "IMM_B", "IMM_W", "IMM_D",  "IMM_WB", "IMM_DB",
   -- action arg (1 byte), int arg, 1 buffer pos (reg/num):
-  "VREG", "SPACE", -- !x64: VREG support NYI.
+  "VREG", "SPACE",
   -- ptrdiff_t arg, 1 buffer pos (address): !x64
   "SETLABEL", "REL_A",
   -- action arg (1 byte) or int arg, 2 buffer pos (link, offset):
@@ -82,6 +82,21 @@ local actargs = { 0 }
 
 -- Current number of section buffer positions for dasm_put().
 local secpos = 1
+
+-- VREG kind encodings (pre-shifted by 5 bits)
+local map_vreg = {
+  ["modrm.rm.m"] = 0x00,
+  ["modrm.rm.r"] = 0x20,
+  ["opcode"] =     0x20,
+  ["sib.base"] =   0x20,
+  ["sib.index"] =  0x40,
+  ["modrm.reg"] =  0x80,
+  ["vex.v"] =      0xa0,
+  ["imm.hi"] =     0xc0,
+}
+
+-- Current number of VREG actions contributing to REX/VEX shrinkage.
+local vreg_shrink_count = 0
 
 ------------------------------------------------------------------------------
 
@@ -132,6 +147,21 @@ local function waction(action, a, num)
   wputxb(assert(map_action[action], "bad action name `"..action.."'"))
   if a then actargs[#actargs+1] = a end
   if a or num then secpos = secpos + (num or 1) end
+end
+
+-- Optionally add a VREG action.
+local function wvreg(kind, vreg, psz, sk, defer)
+  if not vreg then return end
+  waction("VREG", vreg)
+  local b = assert(map_vreg[kind], "bad vreg kind `"..vreg.."'")
+  if b < (sk or 0) then
+    vreg_shrink_count = vreg_shrink_count + 1
+  end
+  if not defer then
+    b = b + vreg_shrink_count * 8
+    vreg_shrink_count = 0
+  end
+  wputxb(b + (psz or 0))
 end
 
 -- Add call to embedded DynASM C code.
@@ -326,6 +356,7 @@ mkrmap("w", "Rw", {"ax", "cx", "dx", "bx", "sp", "bp", "si", "di"})
 mkrmap("b", "Rb", {"al", "cl", "dl", "bl", "ah", "ch", "dh", "bh"})
 map_reg_valid_index[map_archdef.esp] = false
 if x64 then map_reg_valid_index[map_archdef.rsp] = false end
+if x64 then map_reg_needrex[map_archdef.Rb] = true end
 map_archdef["Ra"] = "@"..addrsize
 
 -- FP registers (internally tword sized, but use "f" as operand size).
@@ -463,16 +494,24 @@ local function wputszarg(sz, n)
 end
 
 -- Put multi-byte opcode with operand-size dependent modifications.
-local function wputop(sz, op, rex, vex)
+local function wputop(sz, op, rex, vex, vregr, vregxb)
+  local psz, sk = 0
   if vex then
     local tail
     if vex.m == 1 and band(rex, 11) == 0 then
-      wputb(0xc5)
-      tail = shl(bxor(band(rex, 4), 4), 5)
-    else
+      if x64 and vregxb then
+        sk = map_vreg["modrm.reg"]
+      else
+        wputb(0xc5)
+        tail = shl(bxor(band(rex, 4), 4), 5)
+        psz = 3
+      end
+    end
+    if not tail then
       wputb(0xc4)
       wputb(shl(bxor(band(rex, 7), 7), 5) + vex.m)
       tail = shl(band(rex, 8), 4)
+      psz = 4
     end
     local reg, vreg = 0, nil
     if vex.v then
@@ -482,12 +521,18 @@ local function wputop(sz, op, rex, vex)
     end
     if sz == "y" or vex.l then tail = tail + 4 end
     wputb(tail + shl(bxor(reg, 15), 3) + vex.p)
-    if vreg then waction("VREG", vreg); wputxb(4) end
+    wvreg("vex.v", vreg)
     rex = 0
     if op >= 256 then werror("bad vex opcode") end
+  else
+    if rex ~= 0 then
+      if not x64 then werror("bad operand size") end
+    elseif (vregr or vregxb) and x64 then
+      rex = 0x10
+      sk = map_vreg["vex.v"]
+    end
   end
   local r
-  if rex ~= 0 and not x64 then werror("bad operand size") end
   if sz == "w" then wputb(102) end
   -- Needs >32 bit numbers, but only for crc32 eax, word [ebx]
   if op >= 4294967296 then r = op%4294967296 wputb((op-r)/4294967296) op = r end
@@ -496,20 +541,20 @@ local function wputop(sz, op, rex, vex)
     if rex ~= 0 then
       local opc3 = band(op, 0xffff00)
       if opc3 == 0x0f3a00 or opc3 == 0x0f3800 then
-	wputb(64 + band(rex, 15)); rex = 0
+	wputb(64 + band(rex, 15)); rex = 0; psz = 2
       end
     end
-    wputb(shr(op, 16)); op = band(op, 0xffff)
+    wputb(shr(op, 16)); op = band(op, 0xffff); psz = psz + 1
   end
   if op >= 256 then
     local b = shr(op, 8)
-    if b == 15 and rex ~= 0 then wputb(64 + band(rex, 15)); rex = 0 end
-    wputb(b)
-    op = band(op, 255)
+    if b == 15 and rex ~= 0 then wputb(64 + band(rex, 15)); rex = 0; psz = 2 end
+    wputb(b); op = band(op, 255); psz = psz + 1
   end
-  if rex ~= 0 then wputb(64 + band(rex, 15)) end
+  if rex ~= 0 then wputb(64 + band(rex, 15)); psz = 2 end
   if sz == "b" then op = op - 1 end
   wputb(op)
+  return psz, sk
 end
 
 -- Put ModRM or SIB formatted byte.
@@ -519,7 +564,7 @@ local function wputmodrm(m, s, rm, vs, vrm)
 end
 
 -- Put ModRM/SIB plus optional displacement.
-local function wputmrmsib(t, imark, s, vsreg)
+local function wputmrmsib(t, imark, s, vsreg, psz, sk)
   local vreg, vxreg
   local reg, xreg = t.reg, t.xreg
   if reg and reg < 0 then reg = 0; vreg = t.vreg end
@@ -529,8 +574,8 @@ local function wputmrmsib(t, imark, s, vsreg)
   -- Register mode.
   if sub(t.mode, 1, 1) == "r" then
     wputmodrm(3, s, reg)
-    if vsreg then waction("VREG", vsreg); wputxb(2) end
-    if vreg then waction("VREG", vreg); wputxb(0) end
+    wvreg("modrm.reg", vsreg, psz+1, sk, vreg)
+    wvreg("modrm.rm.r", vreg, psz+1, sk)
     return
   end
 
@@ -544,21 +589,22 @@ local function wputmrmsib(t, imark, s, vsreg)
       -- [xreg*xsc+disp] -> (0, s, esp) (xsc, xreg, ebp)
       wputmodrm(0, s, 4)
       if imark == "I" then waction("MARK") end
-      if vsreg then waction("VREG", vsreg); wputxb(2) end
+      wvreg("modrm.reg", vsreg, psz+1, sk, vxreg)
       wputmodrm(t.xsc, xreg, 5)
-      if vxreg then waction("VREG", vxreg); wputxb(3) end
+      wvreg("sib.index", vxreg, psz+2, sk)
     else
       -- Pure 32 bit displacement.
       if x64 and tdisp ~= "table" then
 	wputmodrm(0, s, 4) -- [disp] -> (0, s, esp) (0, esp, ebp)
+	wvreg("modrm.reg", vsreg, psz+1, sk)
 	if imark == "I" then waction("MARK") end
 	wputmodrm(0, 4, 5)
       else
 	riprel = x64
 	wputmodrm(0, s, 5) -- [disp|rip-label] -> (0, s, ebp)
+	wvreg("modrm.reg", vsreg, psz+1, sk)
 	if imark == "I" then waction("MARK") end
       end
-      if vsreg then waction("VREG", vsreg); wputxb(2) end
     end
     if riprel then -- Emit rip-relative displacement.
       if match("UWSiI", imark) then
@@ -586,16 +632,16 @@ local function wputmrmsib(t, imark, s, vsreg)
   if xreg or band(reg, 7) == 4 then
     wputmodrm(m or 2, s, 4) -- ModRM.
     if m == nil or imark == "I" then waction("MARK") end
-    if vsreg then waction("VREG", vsreg); wputxb(2) end
+    wvreg("modrm.reg", vsreg, psz+1, sk, vxreg or vreg)
     wputmodrm(t.xsc or 0, xreg or 4, reg) -- SIB.
-    if vxreg then waction("VREG", vxreg); wputxb(3) end
-    if vreg then waction("VREG", vreg); wputxb(1) end
+    wvreg("sib.index", vxreg, psz+2, sk, vreg)
+    wvreg("sib.base", vreg, psz+2, sk)
   else
     wputmodrm(m or 2, s, reg) -- ModRM.
     if (imark == "I" and (m == 1 or m == 2)) or
        (m == nil and (vsreg or vreg)) then waction("MARK") end
-    if vsreg then waction("VREG", vsreg); wputxb(2) end
-    if vreg then waction("VREG", vreg); wputxb(1) end
+    wvreg("modrm.reg", vsreg, psz+1, sk, vreg)
+    wvreg("modrm.rm.m", vreg, psz+1, sk)
   end
 
   -- Put displacement.
@@ -1761,10 +1807,11 @@ local function dopattern(pat, args, sz, op, needrex)
       if t.xreg and t.xreg > 7 then rex = rex + 2 end
       if s > 7 then rex = rex + 4 end
       if needrex then rex = rex + 16 end
-      wputop(szov, opcode, rex, vex); opcode = nil
+      local psz, sk = wputop(szov, opcode, rex, vex, s < 0, t.vreg or t.vxreg)
+      opcode = nil
       local imark = sub(pat, -1) -- Force a mark (ugly).
       -- Put ModRM/SIB with regno/last digit as spare.
-      wputmrmsib(t, imark, s, addin and addin.vreg)
+      wputmrmsib(t, imark, s, addin and addin.vreg, psz, sk)
       addin = nil
     elseif map_vexarg[c] ~= nil then -- Encode using VEX prefix
       local b = band(opcode, 255); opcode = shr(opcode, 8)
@@ -1791,8 +1838,8 @@ local function dopattern(pat, args, sz, op, needrex)
 	if szov == "q" and rex == 0 then rex = rex + 8 end
 	if needrex then rex = rex + 16 end
 	if addin and addin.reg == -1 then
-	  wputop(szov, opcode - 7, rex, vex)
-	  waction("VREG", addin.vreg); wputxb(0)
+	  local psz, sk = wputop(szov, opcode - 7, rex, vex, true)
+	  wvreg("opcode", addin.vreg, psz, sk)
 	else
 	  if addin and addin.reg > 7 then rex = rex + 1 end
 	  wputop(szov, opcode, rex, vex)
@@ -1836,7 +1883,7 @@ local function dopattern(pat, args, sz, op, needrex)
 	  local reg = a.reg
 	  if reg < 0 then
 	    wputb(0)
-	    waction("VREG", a.vreg); wputxb(5)
+	    wvreg("imm.hi", a.vreg)
 	  else
 	    wputb(shl(reg, 4))
 	  end
@@ -1988,8 +2035,8 @@ if x64 then
 	rex = a.reg > 7 and 9 or 8
       end
     end
-    wputop(sz, opcode, rex)
-    if vreg then waction("VREG", vreg); wputxb(0) end
+    local psz, sk = wputop(sz, opcode, rex, nil, vreg)
+    wvreg("opcode", vreg, psz, sk)
     waction("IMM_D", format("(unsigned int)(%s)", op64))
     waction("IMM_D", format("(unsigned int)((%s)>>32)", op64))
   end


### PR DESCRIPTION
TL,DR: With this patch, DynASM/x64 VREG operands (that is, `ymm(n)`, `Rq(n)`, etc.) should support all 16 registers in each family rather than just the first 8.

<hr/>

DynASM/x86 VREG actions are relatively simple: when a byte of an instruction contains a 3-bit field representing a register, a VREG action is emitted immediately after said byte, and at runtime it mutates the field to contain the desired register number. There is some complexity around ensuring that `[Rd(n)]` encodes with a signed 8-bit displacement when n==5, and with no displacement otherwise, but that is the main limit of the complexity.

DynASM/x64 operates in a far more complex environment, as it requires 4 bits rather than 3 to encode a register number. Some existing 3-bit fields retained their 3-bit size but gained an extra bit in the REX or VEX prefix (said bits being called R, X, and B), whereas relatively new 3-bit fields gained a 4th bit in-place (that is, in VEX.V and in the high nibble of trailing immediates). The REX prefix can be dropped when R, X, and B are all zero (and W is also zero), whereas the VEX prefix can use a 2-byte form rather than a 3-byte form when X and B are both zero (and the implied opcode prefix encoded in VEX.M is 0F). With respect to VREG operands and these R/X/B bits, some possible behaviours are:
  1. Don't allow VREG operands to set R/X/B (the current behaviour).
  2. Start by assuming that all of R/X/B are zero, but should a VREG operand need to set one of them, insert a REX prefix byte or expand a 2-byte VEX to a 3-byte VEX as necessary.
  3. Should an instruction have VREG operands, always emit a REX prefix or 3-byte VEX, and keep this overlong form even if all of R/X/B end up being zero.
  4. Should an instruction have VREG operands, always emit a REX prefix or 3-byte VEX, but after all VREG operands have been seen, remove the REX prefix or change the 3-byte VEX or a 2-byte VEX if this is possible (the behaviour with this patch).

Behaviour number 1 is clearly undesirable, as it limits the usefulness of VREG operands. Behaviour number 3 is somewhat undesirable, as it doesn't produce the optimal instruction encoding in many cases. Of behaviours 2 and 4, both seem reasonable, but I've opted for 4 over 2: it feels like 4 is easier to implement, and 4 has the nice property of instruction shrinkage being merely an optimisation, whereas the instruction expansion in 2 is more than just an optimisation.

With that behaviour in mind, some possible implementation strategies are:
  1. A new VREX action which appears immediately after REX or VEX bytes, receives copies of the VREG operands, inserts the R/X/B bits into REX/VEX, and possibly removes REX or shrinks VEX.
  2. Like 1, but have the VREX action snoop at the operands of subsequent VREG actions rather than receiving copies.
  3. Teach VREG actions how to find their preceding REX/VEX prefix, have each VREG action set one of R/X/B, and have the last VREG operand for a given instruction optionally remove REX or shrink VEX.

Though I went with strategy number 3 in the end, it is worth briefly considering the other options. Option 1 has the benefit of VREG actions knowing nothing about REX/VEX prefixes, but the operand duplication is displeasing (and behavioural-changing in cases like `Rq(f())` where `f()` has side-effects). Option 2 solves the operand duplication problem, but is slightly tricky to pull off, for a few reasons. One of those is that shrinkage is ideally detected during `dasm_encode` rather than during `dasm_link`, but during `dasm_encode`, the hypothetical VREX action would be seen before any of the associated VREG actions, and therefore shinkage either has to be detected by the VREX action during `dasm_link` or by a VREG action during `dasm_encode`. If the VREG action has to consider shrinkage either way, then option 3 feels nicer than option 2, as option 3 doesn't need to introduce a new action.

That sets the scene: full VREG support, implemented using a prefix-shrinking behaviour, without any new actions. This scene requires a substantial change to the logic for VREG actions, but before explaining the new VREG logic, I feel it worth recapping the old VREG logic. Starting from basics briefly, a VREG action byte is followed by a data byte, and at runtime consumes one buffer slot. In master, the data byte encodes the kind of the VREG operand, and the buffer slot is used to store the register number. The encodings for the data byte are:
<table><tr><th>Value</th><th>Name</th><th>Shift</th><th>Constraints</th><th>Notes</th></tr>
<tr><td>0</td><td><code>opcode</code> or <code>modrm.rm.r</code></td><td>0</td><td/><td/></tr>
<tr><td>1</td><td><code>modrm.rm.m</code> or <code>sib.base</code></td><td>0</td><td>Cannot be 4 [1]</td><td>Controls adjacent DISP</td></tr>
<tr><td>2</td><td><code>modrm.reg</code></td><td>3</td><td/><td/></tr>
<tr><td>3</td><td><code>sib.index</code></td><td>3</td><td>Cannot be 4</td><td/></tr>
<tr><td>4</td><td><code>vex.v</code></td><td>3</td><td/><td/></tr>
<tr><td>5</td><td><code>imm.hi</code></td><td>4</td><td>Cannot be 4 [2]</td><td/></tr>
</table>

[1] This constraint seems somewhat onerous, and is lifted by this patch.
[2] This constraint was an unintentional addition by me; I should have chosen value 6 rather than 5 for `imm.hi`.

With this patch, rather than just encoding the kind, the data byte which follows VREG is split up into three fields. Bits 0 and 1 give a 2-bit unsigned integer, and control REX/VEX shrinkage: any non-zero value means that shrinkage should be considered during the `dasm_encode` processing of this VREG operand (i.e. a non-zero value means that the instruction has a REX or VEX prefix, said prefix is allowed to be dropped (REX) or shrunk (VEX) if all related VREG operands are small, and this VREG operand is the last VREG operand for this instruction which can affect REX/VEX). If the value is non-zero, then the value specifies the number of VREG operands which affect the R/X/B bits of REX or the X/B bits of VEX. Bits 2, 3, and 4 give a 3-bit unsigned integer, which specifies the distance backwards from `cp` during `dasm_encode` to either the REX prefix or to the C4/C5 byte of the VEX prefix. Bits 5, 6, and 7 give a 3-bit unsigned integer specifying the kind. The new kind encodings are:
<table><tr><th>Value</th><th>Name</th><th>Shift</th><th>Bit</th><th>Constraints / Notes</th></tr>
<tr><td>0</td><td><code>modrm.rm.m</code></td><td>0</td><td>B</td><td>Controls adjacent DISP, needs SIB to encode 4 or 12</td></tr>
<tr><td>1</td><td><code>modrm.rm.r</code> or <code>opcode</code> or <code>sib.base</code></td><td>0</td><td>B</td><td>Controls adjacent DISP</td></tr>
<tr><td>2</td><td><code>sib.index</code></td><td>3</td><td>X</td><td>Cannot be 4</td></tr>
<tr><td>4</td><td><code>modrm.reg</code></td><td>3</td><td>R</td><td/></tr>
<tr><td>5</td><td><code>vex.v</code></td><td>3</td><td/><td/></tr>
<tr><td>6</td><td><code>imm.hi</code></td><td>4</td><td/><td/></tr>
</table>
As before, the shift column ends up in non-decreasing order. The value of 3 is skipped over, and as a result, for kinds which require a bit in REX/VEX, dividing the kind by 2 gives the index of the bit in REX. <code>opcode</code> and <code>modrm.rm.r</code> can now nominally control an adjacent DISP, but they shouldn't ever _have_ an adjacent DISP, so the behaviour in that regard shouldn't actually change. The previous constraint of <code>modrm.rm.m</code> not being 4 is lifted by having VREG insert a SIB byte in the case of being asked to encode register 4 or 12. The constraint of <code>sib.base</code> not being 4 is lifted more easily, as there is no architectural constraint against the SIB base field being 4 or 12 (though along with the previous constraint lifting, it requires <code>mrm</code> using -1 rather than 4 as a sentinel value during `dasm_encode`).

In addition to the data byte changing, the buffer slot also changes slightly. In particular, bits 0 through 3 of the buffer slot now contain the register number. Bit 4 is set during `dasm_put` if REX dropping or VEX shrinkage should be performed when `dasm_encode` comes around: this saves `dasm_encode` from having to re-evaluate the shrinkage-checking logic.

I believe that the above gives sufficient commentary on the changes to `dasm_x86.h`. Of course, `dasm_x86.lua` changes too, with the end-effect of the changes to `dasm_x86.lua` being to produce the data expected by the new `dasm_x86.h`. As a slight refactoring, a function called `wvreg` is introduced, and replaces the pattern of `if vreg then waction("VREG", vreg); wputxb(kind) end`. A lot of changes revolve around `wputop`, as it gains several new responsibilities:
  * Forcing a REX prefix or 3-byte VEX if subsequent VREG operands might need R/X/B or X/B bits.
  * Counting the number of bytes from the REX/VEX prefix to the end of the opcode (called `psz`, ends up in bits 2, 3, and 4 of the VREG data byte).
  * Determining whether REX can be removed or VEX can be shrunk, should subsequent VREG operands transpire to not need extra bits (`sk` ends up as `nil` if no shrinkage can be performed, otherwise it ends up as the smallest kind which doesn't affect shrinkage).

The `psz` and `sk` values flow from `wputop` to both `wputmrmsib` and `wvreg`.