### PR TITLE
Improved AVX/AES support

### DIFF
--- a/dynasm/dasm_x86.lua
+++ b/dynasm/dasm_x86.lua
@@ -1521,6 +1521,12 @@ local map_op = {
 
   -- AVX, AVX2 integer ops
   -- In general, xmm requires AVX, ymm requires AVX2.
+  vaesdec_3 =  "rrmo:660F38VDErM",
+  vaesdeclast_3 = "rrmo:660F38VDFrM",
+  vaesenc_3 =  "rrmo:660F38VDCrM",
+  vaesenclast_3 = "rrmo:660F38VDDrM",
+  vaesimc_2 =  "rmo:660F38uDBrM",
+  vaeskeygenassist_3 = "rmio:660F3AuDFrMU",
   vlddqu_2 =	"rxoy:F20FuF0rM",
   vmaskmovdqu_2 = "rro:660FuF7rM",
   vmovdqa_2 =	"rmoy:660Fu6FrM|mroy:660Fu7FRm",

--- a/src/jit/dis_x86.lua
+++ b/src/jit/dis_x86.lua
@@ -239,6 +239,9 @@ nil,"||psrlvVSXrvm","||psravdXrvm","||psllvVSXrvm",
 --8x
 [0x8c] = "||pmaskmovXrvVSm",
 [0x8e] = "||pmaskmovVSmXvr",
+--Dx
+[0xdc] = "||aesencXrvm", [0xdd] = "||aesenclastXrvm",
+[0xde] = "||aesdecXrvm", [0xdf] = "||aesdeclastXrvm",
 --Fx
 [0xf0] = "|||crc32TrBmt",[0xf1] = "|||crc32TrVmt",
 },
@@ -262,12 +265,14 @@ nil,nil,nil,nil,
 [0x40] = "||dppsXrvmu",
 [0x41] = "||dppdXrvmu",
 [0x42] = "||mpsadbwXrvmu",
+[0x44] = "||pclmulqdqXrvmu",
 [0x46] = "||perm2i128Xrvmu",
 [0x4a] = "||blendvpsXrvmb",[0x4b] = "||blendvpdXrvmb",
 [0x4c] = "||pblendvbXrvmb",
 --6x
 [0x60] = "||pcmpestrmXrmu",[0x61] = "||pcmpestriXrmu",
 [0x62] = "||pcmpistrmXrmu",[0x63] = "||pcmpistriXrmu",
+[0xdf] = "||aeskeygenassistXrmu",
 },
 }
 

--- a/src/jit/dis_x86.lua
+++ b/src/jit/dis_x86.lua
@@ -158,8 +158,8 @@ local map_opc2 = {
 "||punpcklqdqXrvm","||punpckhqdqXrvm",
 "movPrVSm","movqMrm|movdquXrm|movdqaXrm",
 --7x
-"pshufwMrmu|pshufhwXrmu|pshufdXrmu|pshuflwXrmu","pshiftw!Pmu",
-"pshiftd!Pmu","pshiftq!Mmu||pshiftdq!Xmu",
+"pshufwMrmu|pshufhwXrmu|pshufdXrmu|pshuflwXrmu","pshiftw!Pvmu",
+"pshiftd!Pvmu","pshiftq!Mvmu||pshiftdq!Xvmu",
 "pcmpeqbPrvm","pcmpeqwPrvm","pcmpeqdPrvm","emms*|",
 "vmreadUmr||extrqXmuu$|insertqXrmuu$","vmwriteUrm||extrqXrm$|insertqXrm$",
 nil,nil,


### PR DESCRIPTION
#93 added AES instructions to DynASM/x86, but not to LuaJIT's x86 disassembler. This is now remedied.

#93 added AES instructions to DynASM/x86, and #95 added AVX support to DynASM/x86, but the combination of those two things (i.e. AVX AES instructions) didn't live in either PR. This is now remedied.

#95 added AVX support to LuaJIT's x86 disassembler, but didn't fully teach it all the corners of AVX. One such missing corner was AVX shift instructions, which is now remedied.