### PR TITLE
Add funcbcline in jit.util

### DIFF
--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -267,6 +267,18 @@ LJLIB_CF(jit_util_funcuvname)
   return 0;
 }
 
+LJLIB_CF(jit_util_funcbcline)
+{
+  GCproto *pt = check_Lproto(L, 0);
+  uint32_t idx = (uint32_t)lj_lib_checkint(L, 2);
+  BCLine line = lj_debug_line(pt, idx);
+  if (line != 0) {
+    setintV(L->top-1, line);
+    return 1;
+  }
+  return 0;
+}
+
 /* -- Reflection API for traces ------------------------------------------- */
 
 #if LJ_HASJIT


### PR DESCRIPTION
We are building a simple Lua lint on top of `jit.util`. In particular, we check the bytecode for `GGET` and `GSET` instructions. If the variable name looks non-standard, we emit a warning — it looks like someone unintentionally created a global instead of a local.

It would be great if it was possible to tell source line number precisely from `func, pc`. The best available option is to get the line range of the function definition from `funcinfo`. Unfortunately, it is imprecise.

Suggest adding `funcbcline` — like `funcbc`, returns the line number.