### PR TITLE
Don't count tail calls towards loop unroll limit.

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -651,8 +651,14 @@ void lj_record_tailcall(jit_State *J, BCReg func, ptrdiff_t nargs)
   memmove(&J->base[-1], &J->base[func], sizeof(TRef)*(J->maxslot+1));
   /* Note: the new TREF_FRAME is now at J->base[-1] (even for slot #0). */
   /* Tailcalls can form a loop, so count towards the loop unroll limit. */
-  if (++J->tailcalled > J->loopunroll)
-    lj_trace_err(J, LJ_TRERR_LUNROLL);
+
+  J->tailcalled++;
+
+  /* Although it's true that tail calls can form a loop, the Lua programming
+  ** idiom does not encourage this.  Instead of counting tail calls towards the
+  ** unroll limit and potentially causing important traces without loops to
+  ** abort, eventually blacklist, and fall back to the interpreter, just rely on
+  ** JIT_P_maxrecord to catch runaway tail-call loops. */
 }
 
 /* Check unroll limits for down-recursion. */


### PR DESCRIPTION
I think tail calls should probably not be counted towards the loop unroll limit.  They usually aren't loops; they're usually just calls that happen to be in tail position.  If the loop unroll limit is triggered via too many tail calls and the trace is hot, the whole thing can end up being blacklisted, which is a bit of a shame.

This happened in my app; see https://github.com/Igalia/snabbswitch/pull/196 and https://github.com/Igalia/snabbswitch/pull/198 for a discussion.
