### PR TITLE
Windows/x64: Support exception unwinding during JIT-compiled FFI calls

### DIFF
--- a/src/lj_err.h
+++ b/src/lj_err.h
@@ -38,4 +38,8 @@ LJ_FUNC_NORET void lj_err_argv(lua_State *L, int narg, ErrMsg em, ...);
 LJ_FUNC_NORET void lj_err_argtype(lua_State *L, int narg, const char *xname);
 LJ_FUNC_NORET void lj_err_argt(lua_State *L, int narg, int tt);
 
+#if LJ_HASJIT && LJ_ABI_WIN && LJ_TARGET_X64
+LJ_FUNC int lj_err_unwind_trace_win64(void* r, void* tcf, void* ctx, void* d);
+#endif
+
 #endif

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -416,6 +416,9 @@ typedef struct jit_State {
   MCode *mcbot;		/* Bottom of current mcode area. */
   size_t szmcarea;	/* Size of current mcode area. */
   size_t szallmcarea;	/* Total size of all allocated mcode areas. */
+#if LJ_ABI_WIN && LJ_TARGET_X64
+  MCode *win64tracexdata;
+#endif
 
   TValue errinfo;	/* Additional info element for trace errors. */
 

--- a/src/lj_vm.h
+++ b/src/lj_vm.h
@@ -19,6 +19,9 @@ LJ_ASMF_NORET void LJ_FASTCALL lj_vm_unwind_c(void *cframe, int errcode);
 LJ_ASMF_NORET void LJ_FASTCALL lj_vm_unwind_ff(void *cframe);
 LJ_ASMF void lj_vm_unwind_c_eh(void);
 LJ_ASMF void lj_vm_unwind_ff_eh(void);
+#if LJ_HASJIT && LJ_TARGET_X64 && LJ_ABI_WIN
+LJ_ASMF void lj_vm_unwind_trace_eh(void);
+#endif
 #if LJ_TARGET_X86ORX64
 LJ_ASMF void lj_vm_unwind_rethrow(void);
 #endif

--- a/src/vm_x86.dasc
+++ b/src/vm_x86.dasc
@@ -590,6 +590,16 @@ static void build_subroutines(BuildCtx *ctx)
   |  set_vmstate INTERP
   |  jmp ->vm_returnc			// Increments RD/MULTRES and returns.
   |
+  |.if JIT and X64WIN
+  |->vm_unwind_trace_eh:		// Landing pad for external unwinder.
+  |  add rsp, rax
+  |  and rsp, CFRAME_RAWMASK
+  |  test eax, CFRAME_UNWIND_FF
+  |  jnz ->vm_unwind_ff_eh
+  |  mov eax, LUA_ERRRUN
+  |  jmp ->vm_unwind_c_eh
+  |.endif
+  |
   |//-----------------------------------------------------------------------
   |//-- Grow stack for calls -----------------------------------------------
   |//-----------------------------------------------------------------------


### PR DESCRIPTION
The FFI documentation currently states, under the heading of "missing features", that "C++ exception interoperability does not extend to C functions called via the FFI, if the call is compiled". This feature is no longer missing for Windows/x64 (it remains missing everywhere else).

This support comes at a constant cost per mcode region (16 bytes, plus a call to `RtlInstallFunctionTableCallback` and the state it maintains behind the scenes, plus 80 bytes in some mcode regions), plus a constant cost per trace (32 bytes). When an exception is thrown, the time cost is linear in the number of traces in an mcode region, and - depending on how clever `RtlInstallFunctionTableCallback` is or isn't behind the scenes - possibly also linear in the number of mcode regions).