### PR TITLE
Fix formatting of some small denormals at low precision.

### DIFF
--- a/src/lj_strfmt_num.c
+++ b/src/lj_strfmt_num.c
@@ -364,6 +364,7 @@ static char *lj_strfmt_wfnum(SBuf *sb, SFormat sf, lua_Number n, char *p)
       /* Precision is sufficiently low that rescaling will probably work. */
       if ((ndebias = rescale_e[e >> 6])) {
 	t.n = n * rescale_n[e >> 6];
+	if (LJ_UNLIKELY(!e)) t.n *= 1e10, ndebias -= 10;
 	t.u64 -= 2; /* Convert 2ulp below (later we convert 2ulp above). */
 	nd[0] = 0x100000 | (t.u32.hi & 0xfffff);
 	e = ((t.u32.hi >> 20) & 0x7ff) - 1075 - (ND_MUL2K_MAX_SHIFT < 29);


### PR DESCRIPTION
Rescaling of particularly small denormals could result in `lua_assert(0 <= eidx && eidx < 128);` failing, with `eidx` going as low as -33. The rescaling coefficient for denormals is already 1e308; any higher would hit +inf, and so instead denormals now get a second rescaling push, which ensures `0 <= eidx`.

For example, `0x1.0E00D1p-1050` formatted as `%.9e` would previously give `8.742456524e-317`, whereas it should have given `8.742456525e-317` (note `4` vs `5` in the last place). Ditto for `0x1.1Cp-1068` formatted as `%.13e`: it gave `3.5078660854728e-322` rather than `3.5078660854729e-322` (`8` vs `9` in the last place).