### PR TITLE
Add extra guard when recording `select(x, ...)` with off-trace varargs

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -1693,8 +1693,11 @@ static int select_detect(jit_State *J)
   BCIns ins = J->pc[1];
   if (bc_op(ins) == BC_CALLM && bc_b(ins) == 2 && bc_c(ins) == 1) {
     cTValue *func = &J->L->base[bc_a(ins)];
-    if (tvisfunc(func) && funcV(func)->c.ffid == FF_select)
+    if (tvisfunc(func) && funcV(func)->c.ffid == FF_select) {
+      TRef kfunc = lj_ir_kfunc(J, funcV(func));
+      emitir(IRTG(IR_EQ, IRT_FUNC), getslot(J, bc_a(ins)), kfunc);
       return 1;
+    }
   }
   return 0;
 }


### PR DESCRIPTION
For example, the following previously failed when it got jitted:

    local select = select
    local exptyp = "number"
    local function f(...)
      for i = 1, 100 do
        assert(type((select('#', ...))) == exptyp)
        if i == 75 then
          select = function() return "" end
          exptyp = "string"
        end
      end
    end
    f(1)