### PR TITLE
Fix UCLO in vm_x64.dasc: openupval is a 64-bit pointer

### DIFF
--- a/src/vm_x64.dasc
+++ b/src/vm_x64.dasc
@@ -3516,7 +3516,7 @@ static void build_ins(BuildCtx *ctx, BCOp op, int defop)
     |  ins_AD	// RA = level, RD = target
     |  branchPC RD			// Do this first to free RD.
     |  mov L:RB, SAVE_L
-    |  cmp dword L:RB->openupval, 0
+    |  cmp qword L:RB->openupval, 0
     |  je >1
     |  mov L:RB->base, BASE
     |  lea CARG2, [BASE+RA*8]		// Caveat: CARG2 == BASE


### PR DESCRIPTION
`BC_UCLO` implementation is using incorrect pointer size when checking for open upvalues. 

This will cause wrong behavior if we happen to have an upvalue allocated precisely at `0xXXXXXXXX00000000`