### PR TITLE
Fix misleading-indentation warnings under GCC 6.0

### DIFF
--- a/src/lj_cparse.c
+++ b/src/lj_cparse.c
@@ -297,13 +297,21 @@ static CPToken cp_next_(CPState *cp)
       else return '/';
       break;
     case '|':
-      if (cp_get(cp) != '|') return '|'; cp_get(cp); return CTOK_OROR;
+      if (cp_get(cp) != '|') return '|';
+      cp_get(cp);
+      return CTOK_OROR;
     case '&':
-      if (cp_get(cp) != '&') return '&'; cp_get(cp); return CTOK_ANDAND;
+      if (cp_get(cp) != '&') return '&';
+      cp_get(cp);
+      return CTOK_ANDAND;
     case '=':
-      if (cp_get(cp) != '=') return '='; cp_get(cp); return CTOK_EQ;
+      if (cp_get(cp) != '=') return '=';
+      cp_get(cp);
+      return CTOK_EQ;
     case '!':
-      if (cp_get(cp) != '=') return '!'; cp_get(cp); return CTOK_NE;
+      if (cp_get(cp) != '=') return '!';
+      cp_get(cp);
+      return CTOK_NE;
     case '<':
       if (cp_get(cp) == '=') { cp_get(cp); return CTOK_LE; }
       else if (cp->c == '<') { cp_get(cp); return CTOK_SHL; }
@@ -313,7 +321,9 @@ static CPToken cp_next_(CPState *cp)
       else if (cp->c == '>') { cp_get(cp); return CTOK_SHR; }
       return '>';
     case '-':
-      if (cp_get(cp) != '>') return '-'; cp_get(cp); return CTOK_DEREF;
+      if (cp_get(cp) != '>') return '-';
+      cp_get(cp);
+      return CTOK_DEREF;
     case '$':
       return cp_param(cp);
     case '\0': return CTOK_EOF;

--- a/src/lj_strfmt.c
+++ b/src/lj_strfmt.c
@@ -98,11 +98,15 @@ char * LJ_FASTCALL lj_strfmt_wint(char *p, int32_t k)
   uint32_t u = (uint32_t)k;
   if (k < 0) { u = (uint32_t)-k; *p++ = '-'; }
   if (u < 10000) {
-    if (u < 10) goto dig1; if (u < 100) goto dig2; if (u < 1000) goto dig3;
+    if (u < 10) goto dig1;
+    if (u < 100) goto dig2;
+    if (u < 1000) goto dig3;
   } else {
     uint32_t v = u / 10000; u -= v * 10000;
     if (v < 10000) {
-      if (v < 10) goto dig5; if (v < 100) goto dig6; if (v < 1000) goto dig7;
+      if (v < 10) goto dig5;
+      if (v < 100) goto dig6; 
+      if (v < 1000) goto dig7;
     } else {
       uint32_t w = v / 10000; v -= w * 10000;
       if (w >= 10) WINT_R(w, 10, 10)


### PR DESCRIPTION
A lot of noise warning under the latest GCC 6.0 
```
lj_cparse.c:300:7: warning: this ‘if’ clause does not guard... [-Wmisleading-indentation]
       if (cp_get(cp) != '|') return '|'; cp_get(cp); return CTOK_OROR;
       ^~
lj_cparse.c:300:42: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘if’
       if (cp_get(cp) != '|') return '|'; cp_get(cp); return CTOK_OROR;
                                          ^~~~~~
```

gcc version 6.0.0 20160414 (experimental) [trunk revision 234994] (Debian 6.0.1-1) 

https://gcc.gnu.org/gcc-6/porting_to.html:

> A new warning -Wmisleading-indentation was added to -Wall, warning about places where the indentation of the code might mislead a human reader about the control flow
