### PR TITLE
Smart string hashing

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -146,6 +146,18 @@ XCFLAGS=
 #XCFLAGS+= -DLUA_USE_ASSERT
 #
 ##############################################################################
+############################  STRING INTERNING   #############################
+##############################################################################
+# Define LuaJIT string interning behaviour
+#
+# commented or LUAJIT_SMART_STRINGS=0 - no attepmt to recover from collisions,
+#   only "classic LuaJIT" hashing used - max 16bytes from string is hashed.
+# LUAJIT_SMART_STRINGS=1 - use full string hashing for collisioned strings.
+#   if collision chain is longer than 10 and string is longer than 12bytes,
+#   then "fast and dumb" whole string hash function used.
+XCFLAGS+= -DLUAJIT_SMART_STRINGS=1
+#
+##############################################################################
 # You probably don't need to change anything below this line!
 ##############################################################################
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -155,6 +155,9 @@ XCFLAGS=
 # LUAJIT_SMART_STRINGS=1 - use full string hashing for collisioned strings.
 #   if collision chain is longer than 10 and string is longer than 12bytes,
 #   then "fast and dumb" whole string hash function used.
+# LUAJIT_SMART_STRINGS=2 - use slow strong hashing for collisioned strings.
+#   if collision chain is longer than 10, then all new strings are hashed
+#   using 32bit cousine to SipHash
 XCFLAGS+= -DLUAJIT_SMART_STRINGS=1
 #
 ##############################################################################

--- a/src/lib_ffi.c
+++ b/src/lib_ffi.c
@@ -727,7 +727,7 @@ LJLIB_CF(ffi_abi)	LJLIB_REC(.)
 {
   GCstr *s = lj_lib_checkstr(L, 1);
   int b = 0;
-  switch (s->hash) {
+  switch (lj_str_fast_hash(s)) {
 #if LJ_64
   case H_(849858eb,ad35fd06): b = 1; break;  /* 64bit */
 #else

--- a/src/lj_cparse.c
+++ b/src/lj_cparse.c
@@ -1059,7 +1059,7 @@ static void cp_decl_gccattribute(CPState *cp, CPDecl *decl)
     if (cp->tok == CTOK_IDENT) {
       GCstr *attrstr = cp->str;
       cp_next(cp);
-      switch (attrstr->hash) {
+      switch (lj_str_fast_hash(attrstr)) {
       case H_(64a9208e,8ce14319): case H_(8e6331b2,95a282af):  /* aligned */
 	cp_decl_align(cp, decl);
 	break;
@@ -1718,16 +1718,16 @@ static void cp_pragma(CPState *cp, BCLine pragmaline)
 {
   cp_next(cp);
   if (cp->tok == CTOK_IDENT &&
-      cp->str->hash == H_(e79b999f,42ca3e85))  {  /* pack */
+      !strcmp(strdata(cp->str), "pack")) {  /* pack */
     cp_next(cp);
     cp_check(cp, '(');
     if (cp->tok == CTOK_IDENT) {
-      if (cp->str->hash == H_(738e923c,a1b65954)) {  /* push */
+      if (!strcmp(strdata(cp->str), "push")) {  /* push */
 	if (cp->curpack < CPARSE_MAX_PACKSTACK) {
 	  cp->packstack[cp->curpack+1] = cp->packstack[cp->curpack];
 	  cp->curpack++;
 	}
-      } else if (cp->str->hash == H_(6c71cf27,6c71cf27)) {  /* pop */
+      } else if (!strcmp(strdata(cp->str), "pop")) {  /* pop */
 	if (cp->curpack > 0) cp->curpack--;
       } else {
 	cp_errmsg(cp, cp->tok, LJ_ERR_XSYMBOL);

--- a/src/lj_def.h
+++ b/src/lj_def.h
@@ -121,6 +121,7 @@ typedef unsigned int uintptr_t;
 /* A really naive Bloom filter. But sufficient for our needs. */
 typedef uintptr_t BloomFilter;
 #define BLOOM_MASK	(8*sizeof(BloomFilter) - 1)
+#define BLOOM_LOG       (sizeof(BloomFilter)==4?5:6)
 #define bloombit(x)	((uintptr_t)1 << ((x) & BLOOM_MASK))
 #define bloomset(b, x)	((b) |= bloombit((x)))
 #define bloomtest(b, x)	((b) & bloombit((x)))

--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -402,6 +402,33 @@ static GCRef *gc_sweep(global_State *g, GCRef *p, uint32_t lim)
   return p;
 }
 
+/* Partial sweep of a GC list. */
+static GCRef *gc_sweep_str_chain(global_State *g, GCRef *p)
+{
+  /* Mask with other white and LJ_GC_FIXED. Or LJ_GC_SFIXED on shutdown. */
+  int ow = otherwhite(g);
+  GCobj *o;
+  while ((o = gcref(*p)) != NULL) {
+    if (((o->gch.marked ^ LJ_GC_WHITES) & ow)) {  /* Black or current white? */
+      lua_assert(!isdead(g, o) || (o->gch.marked & LJ_GC_FIXED));
+      makewhite(g, o);  /* Value is alive, change to the current white. */
+#if LUAJIT_SMART_STRINGS
+      if (strsmart(&o->str)) {
+	  MSize h = lj_str_fast_hash(&o->str);
+	  bloomset(g->strbloom.new[0], strbloombits0(h));
+	  bloomset(g->strbloom.new[1], strbloombits1(h));
+      }
+#endif
+      p = &o->gch.nextgc;
+    } else {  /* Otherwise value is dead, free it. */
+      lua_assert(isdead(g, o) || ow == LJ_GC_SFIXED);
+      setgcrefr(*p, o->gch.nextgc);
+      lj_str_free(g, &o->str);
+    }
+  }
+  return p;
+}
+
 /* Check whether we can clear a key or a value slot from a table. */
 static int gc_mayclear(cTValue *o, int val)
 {
@@ -555,7 +582,13 @@ void lj_gc_freeall(global_State *g)
   gc_fullsweep(g, &g->gc.root);
   strmask = g->strmask;
   for (i = 0; i <= strmask; i++)  /* Free all string hash chains. */
-    gc_fullsweep(g, &g->strhash[i]);
+    gc_sweep_str_chain(g, &g->strhash[i]);
+#if LUAJIT_SMART_STRINGS
+  g->strbloom.cur[0] = g->strbloom.new[0];
+  g->strbloom.cur[1] = g->strbloom.new[1];
+  g->strbloom.new[0] = 0;
+  g->strbloom.new[1] = 0;
+#endif
 }
 
 /* -- Collector ----------------------------------------------------------- */
@@ -618,9 +651,16 @@ static size_t gc_onestep(lua_State *L)
     return 0;
   case GCSsweepstring: {
     GCSize old = g->gc.total;
-    gc_fullsweep(g, &g->strhash[g->gc.sweepstr++]);  /* Sweep one chain. */
-    if (g->gc.sweepstr > g->strmask)
+    gc_sweep_str_chain(g, &g->strhash[g->gc.sweepstr++]);  /* Sweep one chain. */
+    if (g->gc.sweepstr > g->strmask) {
       g->gc.state = GCSsweep;  /* All string hash chains sweeped. */
+#if LUAJIT_SMART_STRINGS
+      g->strbloom.cur[0] = g->strbloom.new[0];
+      g->strbloom.cur[1] = g->strbloom.new[1];
+      g->strbloom.new[0] = 0;
+      g->strbloom.new[1] = 0;
+#endif
+    }
     lua_assert(old >= g->gc.total);
     g->gc.estimate -= old - g->gc.total;
     return GCSWEEPCOST;

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -600,6 +600,9 @@ typedef struct global_State {
     BloomFilter cur[2];
     BloomFilter new[2];
   } strbloom;
+# if LUAJIT_SMART_STRINGS == 2
+  uint32_t str_rand_key[2];
+# endif
 #endif
   lua_Alloc allocf;	/* Memory allocator. */
   void *allocd;		/* Memory allocator data. */

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -595,6 +595,12 @@ typedef struct global_State {
   GCRef *strhash;	/* String hash table (hash chain anchors). */
   MSize strmask;	/* String hash mask (size of hash table - 1). */
   MSize strnum;		/* Number of strings in hash table. */
+#if LUAJIT_SMART_STRINGS
+  struct {
+    BloomFilter cur[2];
+    BloomFilter new[2];
+  } strbloom;
+#endif
   lua_Alloc allocf;	/* Memory allocator. */
   void *allocd;		/* Memory allocator data. */
   GCState gc;		/* Garbage collector. */

--- a/src/lj_str.c
+++ b/src/lj_str.c
@@ -152,7 +152,7 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   if (LJ_LIKELY((((uintptr_t)str+len-1) & (LJ_PAGESIZE-1)) <= LJ_PAGESIZE-4)) {
     while (o != NULL) {
       GCstr *sx = gco2str(o);
-      if (sx->len == len && str_fastcmp(str, strdata(sx), len) == 0) {
+      if (sx->hash == h && sx->len == len && str_fastcmp(str, strdata(sx), len) == 0) {
 	/* Resurrect if dead. Can only happen with fixstring() (keywords). */
 	if (isdead(g, o)) flipwhite(o);
 	return sx;  /* Return existing string. */
@@ -162,7 +162,7 @@ GCstr *lj_str_new(lua_State *L, const char *str, size_t lenx)
   } else {  /* Slow path: end of string is too close to a page boundary. */
     while (o != NULL) {
       GCstr *sx = gco2str(o);
-      if (sx->len == len && memcmp(str, strdata(sx), len) == 0) {
+      if (sx->hash == h && sx->len == len && memcmp(str, strdata(sx), len) == 0) {
 	/* Resurrect if dead. Can only happen with fixstring() (keywords). */
 	if (isdead(g, o)) flipwhite(o);
 	return sx;  /* Return existing string. */

--- a/src/lj_str.h
+++ b/src/lj_str.h
@@ -24,4 +24,39 @@ LJ_FUNC void LJ_FASTCALL lj_str_free(global_State *g, GCstr *s);
 #define lj_str_newz(L, s)	(lj_str_new(L, s, strlen(s)))
 #define lj_str_newlit(L, s)	(lj_str_new(L, "" s, sizeof(s)-1))
 
+#if LUAJIT_SMART_STRINGS
+#define strsmartbit     (1<<(sizeof(MSize)*8-1))
+#define strsmart(s)     ((s)->hash & strsmartbit)
+#define strbloombits0(h)  ((h)>>(sizeof(h)*8-1-BLOOM_LOG*2))
+#define strbloombits1(h)  ((h)>>(sizeof(h)*8-1-BLOOM_LOG))
+static LJ_AINLINE MSize lj_str_fast_hash(GCstr* s)
+{
+  const char *str = strdata(s);
+  MSize len = s->len;
+  MSize a, b, h = len;
+  if (!strsmart(s)) {
+    return s->hash;
+  }
+  if (len >= 4) {  /* Caveat: unaligned access! */
+    a = lj_getu32(str);
+    h ^= lj_getu32(str+len-4);
+    b = lj_getu32(str+(len>>1)-2);
+    h ^= b; h -= lj_rol(b, 14);
+    b += lj_getu32(str+(len>>2)-1);
+  } else if (len > 0) {
+    a = *(const uint8_t *)str;
+    h ^= *(const uint8_t *)(str+len-1);
+    b = *(const uint8_t *)(str+(len>>1));
+    h ^= b; h -= lj_rol(b, 14);
+  } else {
+    return s->hash;;
+  }
+  a ^= h; a -= lj_rol(h, 11);
+  b ^= a; b -= lj_rol(a, 25);
+  h ^= b; h -= lj_rol(b, 16);
+  return h & ~strsmartbit;
+}
+#else
+#define lj_str_fast_hash(s) ((s)->hash)
+#endif
 #endif


### PR DESCRIPTION
Use full string hashing when a lot of collisions are generated.
- detect when collision chain is too long.
  "average maximum" chain of table with fill-factor 1.0 is near 7, so if collision chain is longer than 10, then it is bad sign.
- calculate "full" hash for new strings in long collision chain.
- use "bloom" filter to bookkeeping existence of strings with "full" hash.
- refill "bloom" on string sweeping.

Separately:
- first commit adds checking for hash equality when collision chain is traversed.
- last commit adds optional usage of strong hash function for "full hash".

Obsoletes #171 and #169, closes #168
