### PR TITLE
sink_remark_phi must remark if any instruction was marked

### DIFF
--- a/src/lj_opt_sink.c
+++ b/src/lj_opt_sink.c
@@ -153,10 +153,10 @@ static void sink_remark_phi(jit_State *J)
     remark = 0;
     for (ir = IR(J->cur.nins-1); ir->o == IR_PHI; ir--) {
       IRIns *irl = IR(ir->op1), *irr = IR(ir->op2);
-      if (((irl->t.irt ^ irr->t.irt) & IRT_MARK))
-	remark = 1;
-      else if (irl->prev == irr->prev)
+      if (!((irl->t.irt ^ irr->t.irt) & IRT_MARK) && irl->prev == irr->prev)
 	continue;
+      /* Must remark if either was marked. */
+      remark = (~(irl->t.irt & irr->t.irt) & IRT_MARK);
       irt_setmark(IR(ir->op1)->t);
       irt_setmark(IR(ir->op2)->t);
     }

--- a/src/lj_opt_sink.c
+++ b/src/lj_opt_sink.c
@@ -155,7 +155,7 @@ static void sink_remark_phi(jit_State *J)
       IRIns *irl = IR(ir->op1), *irr = IR(ir->op2);
       if (!((irl->t.irt ^ irr->t.irt) & IRT_MARK) && irl->prev == irr->prev)
 	continue;
-      /* Must remark if either was marked. */
+      /* Must remark if any operand will be marked. */
       remark = (~(irl->t.irt & irr->t.irt) & IRT_MARK);
       irt_setmark(IR(ir->op1)->t);
       irt_setmark(IR(ir->op2)->t);


### PR DESCRIPTION
Previous code was only remarking if left and right marks were different - however was *not* remarking if PHI value counts were different, which lead to incorrect sinking on the IR like this:

```
....              SNAP   #0   [ ---- ---- ---- ---- ---- ---- ---- ---- ---- ---- ]
0001 r14   >  cdt SLOAD  #9    T
0002          u16 FLOAD  0001  cdata.ctypeid
0003       >  int EQ     0002  +99
0004 r13      p64 FLOAD  0001  cdata.ptr
0005          p64 ADD    0004  +8
0006 r12      p64 XLOAD  0005
0007 [c]   >+ cdt CNEWI  +99   0006
0008          p64 ADD    0006  +8
0009 rbp    + p64 XLOAD  0008
0010 [8]   >+ cdt CNEWI  +99   0009
0011 rdx   >  cdt SLOAD  #3    T
....              SNAP   #1   [ ---- ---- ---- ---- ---- ---- ---- ---- ---- 0007 0010 ---- ---- ]
0012          u16 FLOAD  0011  cdata.ctypeid
0013       >  int EQ     0012  +102
0014 rcx      p64 FLOAD  0011  cdata.ptr
0015       >  p64 NE     0014  0009
....              SNAP   #2   [ ---- ---- ---- ---- ---- ---- ---- ---- ---- 0007 ]
0016 ------------ LOOP ------------
0017          p64 ADD    0009  +8
0018 rbp    + p64 XLOAD  0017
0019  {sink}+ cdt CNEWI  +99   0018
....              SNAP   #3   [ ---- ---- ---- ---- ---- ---- ---- ---- ---- 0010 0019 ---- ---- ]
0020       >  p64 NE     0018  0014
0021 rax      cdt PHI    0007  0010
0022 rbp      p64 PHI    0009  0018
0023  {sink}  cdt PHI    0010  0019
0024 rbx      nil RENAME 0007  #2
0025 rax      nil RENAME 0007  #2
0025 r15      nil RENAME 0007  #2
```

Notice that here we sunk `0023` which is actually used by `0021`, which can't be sunk as `0017` is not a `PHI`. We did not mark `0023` after we marked `0007` and `0010` because we did not remark. 

Fixes issue #189.