### PR TITLE
Initialise uv->immutable for upvalues of loaded chunks.

### DIFF
--- a/src/lj_func.c
+++ b/src/lj_func.c
@@ -140,7 +140,9 @@ GCfunc *lj_func_newL_empty(lua_State *L, GCproto *pt, GCtab *env)
   /* NOBARRIER: The GCfunc is new (marked white). */
   for (i = 0; i < nuv; i++) {
     GCupval *uv = func_emptyuv(L);
-    uv->dhash = (uint32_t)(uintptr_t)pt ^ ((uint32_t)proto_uv(pt)[i] << 24);
+    uint32_t v = proto_uv(pt)[i];
+    uv->immutable = ((v / PROTO_UV_IMMUTABLE) & 1);
+    uv->dhash = (uint32_t)(uintptr_t)pt ^ (v << 24);
     setgcref(fn->l.uvptr[i], obj2gco(uv));
   }
   fn->l.nupvalues = (uint8_t)nuv;


### PR DESCRIPTION
Previously, the following test case could fail: (though failure is not 100% reliable, as it depends upon memory reuse and the previous contents of said memory)
```lua
for i = 1, 100 do
  local x
  local function f(i) x = i return x end
  f = load(string.dump(f))
  for j = 1, 100 do
    assert(f(j) == j)
  end
end
```