### PR TITLE
feature: show the code lineno in opcode list

### DIFF
--- a/src/jit/bc.lua
+++ b/src/jit/bc.lua
@@ -64,14 +64,14 @@ end
 
 -- Return one bytecode line.
 local function bcline(func, pc, prefix)
-  local ins, m = funcbc(func, pc)
+  local ins, m, l = funcbc(func, pc)
   if not ins then return end
   local ma, mb, mc = band(m, 7), band(m, 15*8), band(m, 15*128)
   local a = band(shr(ins, 8), 0xff)
   local oidx = 6*band(ins, 0xff)
   local op = sub(bcnames, oidx+1, oidx+6)
-  local s = format("%04d %s %-6s %3s ",
-    pc, prefix or "  ", op, ma == 0 and "" or a)
+  local s = format("%04d %7s %s %-6s %3s ",
+    pc, "["..l.."]", prefix or "  ", op, ma == 0 and "" or a)
   local d = shr(ins, 16)
   if mc == 13*128 then -- BCMjump
     return format("%s=> %04d\n", s, pc+d-0x7fff)

--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -23,6 +23,7 @@ local function usage()
   io.stderr:write[[
 Save LuaJIT bytecode: luajit -b[options] input output
   -l        Only list bytecode.
+  -L        Only list bytecode with lineinfo.
   -s        Strip debug info (default).
   -g        Keep debug info.
   -n name   Set module name (default: auto-detect from input name).
@@ -573,9 +574,9 @@ end
 
 ------------------------------------------------------------------------------
 
-local function bclist(input, output)
+local function bclist(input, output, lineinfo)
   local f = readfile(input)
-  require("jit.bc").dump(f, savefile(output, "w"), true)
+  require("jit.bc").dump(f, savefile(output, "w"), true, lineinfo)
 end
 
 local function bcsave(ctx, input, output)
@@ -602,6 +603,7 @@ local function docmd(...)
   local arg = {...}
   local n = 1
   local list = false
+  local lineinfo = false
   local ctx = {
     strip = true, arch = jit.arch, os = string.lower(jit.os),
     type = false, modname = false,
@@ -615,6 +617,9 @@ local function docmd(...)
 	local opt = string.sub(a, m, m)
 	if opt == "l" then
 	  list = true
+    elseif opt == "L" then
+	  list = true
+      lineinfo = true
 	elseif opt == "s" then
 	  ctx.strip = true
 	elseif opt == "g" then
@@ -643,7 +648,7 @@ local function docmd(...)
   end
   if list then
     if #arg == 0 or #arg > 2 then usage() end
-    bclist(arg[1], arg[2] or "-")
+    bclist(arg[1], arg[2] or "-", lineinfo)
   else
     if #arg ~= 2 then usage() end
     bcsave(ctx, arg[1], arg[2])

--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -218,15 +218,20 @@ LJLIB_CF(jit_util_funcbc)
 {
   GCproto *pt = check_Lproto(L, 0);
   BCPos pc = (BCPos)lj_lib_checkint(L, 2);
+  int lineinfo = lj_lib_optint(L, 3, 0);
   if (pc < pt->sizebc) {
     BCIns ins = proto_bc(pt)[pc];
     BCOp op = bc_op(ins);
     lua_assert(op < BC__MAX);
     setintV(L->top, ins);
     setintV(L->top+1, lj_bc_mode[op]);
-    setintV(L->top+2, lj_debug_line(pt, pc));
-    L->top += 3;
-    return 3;
+    L->top += 2;
+    if (lineinfo) {
+      setintV(L->top, lj_debug_line(pt, pc));
+      L->top += 1;
+      return 3;
+    }
+    return 2;
   }
   return 0;
 }

--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -224,8 +224,9 @@ LJLIB_CF(jit_util_funcbc)
     lua_assert(op < BC__MAX);
     setintV(L->top, ins);
     setintV(L->top+1, lj_bc_mode[op]);
-    L->top += 2;
-    return 2;
+    setintV(L->top+2, lj_debug_line(pt, pc));
+    L->top += 3;
+    return 3;
   }
   return 0;
 }


### PR DESCRIPTION
As an example, `luajit -bl sample.lua` can get the result like this:(the second column is the lineno)

```
-- BYTECODE -- opmserver.lua:53-56
0001    [54]    UGET     0   0      ; ngx
0002    [54]    TGETS    0   0   0  ; "req"
0003    [54]    TGETS    0   0   1  ; "discard_body"
0004    [54]    CALL     0   1   1
0005    [55]    UGET     0   1      ; say
0006    [55]    KSTR     1   2      ; "DD "
0007    [55]    VARG     2   0   0
0008    [55]    CALLM    0   1   1
0009    [56]    RET0     0   1
```

With this feature, we can use `luajit -bl code.lua | grep -E "G[SG]ET"` to check unexpected global variable, like [lua-releng](https://github.com/openresty/nginx-devel-utils/blob/master/lua-releng) does (luac -p -l | | grep -E "[GS]ETGLOBAL").
