### PR TITLE
Minor fix in table propagation

### DIFF
--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -307,7 +307,7 @@ static size_t propagatemark(global_State *g)
     if (gc_traverse_tab(g, t) > 0)
       black2gray(o);  /* Keep weak tables gray. */
     return sizeof(GCtab) + sizeof(TValue) * t->asize +
-			   sizeof(Node) * (t->hmask + 1);
+	   (t->hmask ? sizeof(Node) * (t->hmask + 1) : 0);
   } else if (LJ_LIKELY(gct == ~LJ_TFUNC)) {
     GCfunc *fn = gco2func(o);
     gc_traverse_func(g, fn);


### PR DESCRIPTION
Dear all,
there's a minor issue in propagatemark function, causing lj_gc_step to perform fewer propagation steps than expected. The reason for this issue is wrong calculation of table size in case of empty hash part. In this case, propagatemark returns excess sizeof(Node). This patch fixes the issue in master. Branch 'v2.1' is to be fixed in the same way.