### PR TITLE
unbind lj_parse.c and lib_ffi.c from lj_str_new

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -641,6 +641,10 @@ $(LJVM_BOUT): $(BUILDVM_T)
 	$(E) "BUILDVM   $@"
 	$(Q)$(BUILDVM_X) -m $(LJVM_MODE) -o $@
 
+lj_known_strings.h: $(DASM_DEP) lj_cparse.c lib_ffi.c known_strings.lua
+	$(E) "CALCHASH  $@"
+	$(Q) cat lj_cparse.c lib_ffi.c | $(HOST_LUA) known_strings.lua > lj_known_strings.h
+
 lj_bcdef.h: $(BUILDVM_T) $(LJLIB_C)
 	$(E) "BUILDVM   $@"
 	$(Q)$(BUILDVM_X) -m bcdef -o $@ $(LJLIB_C)

--- a/src/Makefile.dep
+++ b/src/Makefile.dep
@@ -17,7 +17,7 @@ lib_ffi.o: lib_ffi.c lua.h luaconf.h lauxlib.h lualib.h lj_obj.h lj_def.h \
  lj_arch.h lj_gc.h lj_err.h lj_errmsg.h lj_str.h lj_tab.h lj_meta.h \
  lj_ctype.h lj_cparse.h lj_cdata.h lj_cconv.h lj_carith.h lj_ccall.h \
  lj_ccallback.h lj_clib.h lj_strfmt.h lj_ff.h lj_ffdef.h lj_lib.h \
- lj_libdef.h
+ lj_known_strings.h lj_libdef.h
 lib_init.o: lib_init.c lua.h luaconf.h lauxlib.h lualib.h lj_arch.h
 lib_io.o: lib_io.c lua.h luaconf.h lauxlib.h lualib.h lj_obj.h lj_def.h \
  lj_arch.h lj_gc.h lj_err.h lj_errmsg.h lj_buf.h lj_str.h lj_state.h \
@@ -85,7 +85,8 @@ lj_clib.o: lj_clib.c lj_obj.h lua.h luaconf.h lj_def.h lj_arch.h lj_gc.h \
  lj_cdata.h lj_clib.h lj_strfmt.h
 lj_cparse.o: lj_cparse.c lj_obj.h lua.h luaconf.h lj_def.h lj_arch.h \
  lj_gc.h lj_err.h lj_errmsg.h lj_buf.h lj_str.h lj_ctype.h lj_cparse.h \
- lj_frame.h lj_bc.h lj_vm.h lj_char.h lj_strscan.h lj_strfmt.h
+ lj_frame.h lj_bc.h lj_vm.h lj_char.h lj_strscan.h lj_strfmt.h \
+ lj_known_strings.h
 lj_crecord.o: lj_crecord.c lj_obj.h lua.h luaconf.h lj_def.h lj_arch.h \
  lj_err.h lj_errmsg.h lj_tab.h lj_frame.h lj_bc.h lj_ctype.h lj_gc.h \
  lj_cdata.h lj_cparse.h lj_cconv.h lj_carith.h lj_clib.h lj_ccall.h \
@@ -219,15 +220,15 @@ ljamalg.o: ljamalg.c lua.h luaconf.h lauxlib.h lj_gc.c lj_obj.h lj_def.h \
  lj_parse.h lj_parse.c lj_bcread.c lj_bcdump.h lj_bcwrite.c lj_load.c \
  lj_ctype.c lj_cdata.c lj_cconv.h lj_cconv.c lj_ccall.c lj_ccall.h \
  lj_ccallback.c lj_target.h lj_target_*.h lj_mcode.h lj_carith.c \
- lj_carith.h lj_clib.c lj_clib.h lj_cparse.c lj_cparse.h lj_lib.c lj_ir.c \
- lj_ircall.h lj_iropt.h lj_opt_mem.c lj_opt_fold.c lj_folddef.h \
- lj_opt_narrow.c lj_opt_dce.c lj_opt_loop.c lj_snap.h lj_opt_split.c \
- lj_opt_sink.c lj_mcode.c lj_snap.c lj_record.c lj_record.h lj_ffrecord.h \
- lj_crecord.c lj_crecord.h lj_ffrecord.c lj_recdef.h lj_asm.c lj_asm.h \
- lj_emit_*.h lj_asm_*.h lj_trace.c lj_gdbjit.h lj_gdbjit.c lj_alloc.c \
- lib_aux.c lib_base.c lj_libdef.h lib_math.c lib_string.c lib_table.c \
- lib_io.c lib_os.c lib_package.c lib_debug.c lib_bit.c lib_jit.c \
- lib_ffi.c lib_init.c
+ lj_carith.h lj_clib.c lj_clib.h lj_cparse.c lj_cparse.h \
+ lj_known_strings.h lj_lib.c lj_ir.c lj_ircall.h lj_iropt.h lj_opt_mem.c \
+ lj_opt_fold.c lj_folddef.h lj_opt_narrow.c lj_opt_dce.c lj_opt_loop.c \
+ lj_snap.h lj_opt_split.c lj_opt_sink.c lj_mcode.c lj_snap.c lj_record.c \
+ lj_record.h lj_ffrecord.h lj_crecord.c lj_crecord.h lj_ffrecord.c \
+ lj_recdef.h lj_asm.c lj_asm.h lj_emit_*.h lj_asm_*.h lj_trace.c \
+ lj_gdbjit.h lj_gdbjit.c lj_alloc.c lib_aux.c lib_base.c lj_libdef.h \
+ lib_math.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c \
+ lib_debug.c lib_bit.c lib_jit.c lib_ffi.c lib_init.c
 luajit.o: luajit.c lua.h luaconf.h lauxlib.h lualib.h luajit.h lj_arch.h
 host/buildvm.o: host/buildvm.c host/buildvm.h lj_def.h lua.h luaconf.h \
  lj_arch.h lj_obj.h lj_def.h lj_arch.h lj_gc.h lj_obj.h lj_bc.h lj_ir.h \

--- a/src/known_strings.lua
+++ b/src/known_strings.lua
@@ -1,0 +1,49 @@
+local function hash(str)
+    -- this function should exactly match lj_ks function below
+    local h = 0
+    local l, r
+    for i=1,#str do
+        h = h * 9 + string.byte(str, i)
+        h = h % 0x100000000
+        -- h = lj_rol(h, 7) = (h<<7) | (h>>25)
+        l = h * 128
+        r = h / 33554432
+        h = l % 0x100000000 + (r - r%1)
+    end
+    return h
+end
+local all = {}
+while true do
+    s = io.read('*l')
+    if not s then break end
+    for w in string.gmatch(s, "LJ_KS_[_%w]+") do
+        all[w] = true
+    end
+end
+io.write([[
+#ifndef LJ_KNOWN_STRINGS_H
+#define LJ_KNOWN_STRINGS_H
+/* small hash function for lj_cparse.c and lib_ffi.c */
+static LJ_AINLINE uint32_t lj_ks(GCstr* s)
+{
+  uint32_t h = 0;
+  const uint8_t* v = (const uint8_t*)strdata(s);
+  /* do not use s->len for loop cause clang produces bad code then */
+  for (; *v; v++) {
+    h = h*9 + *v;
+    h = lj_rol(h, 7);
+  }
+  return h;
+}
+]])
+local keys = {}
+for w, _ in pairs(all) do
+    table.insert(keys, w)
+end
+table.sort(keys)
+for _, w in ipairs(keys) do
+    local h = hash(string.sub(w, 7, -1))
+    local s = string.format("#define %s\t0x%08x\n", w, h)
+    io.write(s)
+end
+io.write("#endif\n")

--- a/src/lib_ffi.c
+++ b/src/lib_ffi.c
@@ -32,6 +32,7 @@
 #include "lj_strfmt.h"
 #include "lj_ff.h"
 #include "lj_lib.h"
+#include "lj_known_strings.h"
 
 /* -- C type checks ------------------------------------------------------- */
 
@@ -720,36 +721,34 @@ LJLIB_CF(ffi_fill)	LJLIB_REC(.)
   return 0;
 }
 
-#define H_(le, be)	LJ_ENDIAN_SELECT(0x##le, 0x##be)
-
 /* Test ABI string. */
 LJLIB_CF(ffi_abi)	LJLIB_REC(.)
 {
   GCstr *s = lj_lib_checkstr(L, 1);
   int b = 0;
-  switch (s->hash) {
+  switch (lj_ks(s)) {
 #if LJ_64
-  case H_(849858eb,ad35fd06): b = 1; break;  /* 64bit */
+  case LJ_KS_64bit: b = 1; break;  /* 64bit */
 #else
-  case H_(662d3c79,d0e22477): b = 1; break;  /* 32bit */
+  case LJ_KS_32bit: b = 1; break;  /* 32bit */
 #endif
 #if LJ_ARCH_HASFPU
-  case H_(e33ee463,e33ee463): b = 1; break;  /* fpu */
+  case LJ_KS_fpu: b = 1; break;  /* fpu */
 #endif
 #if LJ_ABI_SOFTFP
-  case H_(61211a23,c2e8c81c): b = 1; break;  /* softfp */
+  case LJ_KS_softfp: b = 1; break;  /* softfp */
 #else
-  case H_(539417a8,8ce0812f): b = 1; break;  /* hardfp */
+  case LJ_KS_hardfp: b = 1; break;  /* hardfp */
 #endif
 #if LJ_ABI_EABI
-  case H_(2182df8f,f2ed1152): b = 1; break;  /* eabi */
+  case LJ_KS_eabi: b = 1; break;  /* eabi */
 #endif
 #if LJ_ABI_WIN
-  case H_(4ab624a8,4ab624a8): b = 1; break;  /* win */
+  case LJ_KS_win: b = 1; break;  /* win */
 #endif
-  case H_(3af93066,1f001464): b = 1; break;  /* le/be */
+  case LJ_ENDIAN_SELECT(LJ_KS_le, LJ_KS_be): b = 1; break;  /* le/be */
 #if LJ_GC64
-  case H_(9e89d2c9,13c83c92): b = 1; break;  /* gc64 */
+  case LJ_KS_gc64: b = 1; break;  /* gc64 */
 #endif
   default:
     break;

--- a/src/lj_cparse.c
+++ b/src/lj_cparse.c
@@ -17,6 +17,7 @@
 #include "lj_char.h"
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
+#include "lj_known_strings.h"
 
 /*
 ** Important note: this is NOT a validating C parser! This is a minimal
@@ -929,8 +930,6 @@ static CTypeID cp_decl_intern(CPState *cp, CPDecl *decl)
 
 /* -- C declaration parser ------------------------------------------------ */
 
-#define H_(le, be)	LJ_ENDIAN_SELECT(0x##le, 0x##be)
-
 /* Reset declaration state to declaration specifier. */
 static void cp_decl_reset(CPDecl *decl)
 {
@@ -1059,44 +1058,44 @@ static void cp_decl_gccattribute(CPState *cp, CPDecl *decl)
     if (cp->tok == CTOK_IDENT) {
       GCstr *attrstr = cp->str;
       cp_next(cp);
-      switch (attrstr->hash) {
-      case H_(64a9208e,8ce14319): case H_(8e6331b2,95a282af):  /* aligned */
+      switch (lj_ks(attrstr)) {
+      case LJ_KS_aligned: case LJ_KS___aligned__: /* aligned */
 	cp_decl_align(cp, decl);
 	break;
-      case H_(42eb47de,f0ede26c): case H_(29f48a09,cf383e0c):  /* packed */
+      case LJ_KS_packed: case LJ_KS___packed__: /* packed */
 	decl->attr |= CTFP_PACKED;
 	break;
-      case H_(0a84eef6,8dfab04c): case H_(995cf92c,d5696591):  /* mode */
+      case LJ_KS_mode: case LJ_KS___mode__:  /* mode */
 	cp_decl_mode(cp, decl);
 	break;
-      case H_(0ab31997,2d5213fa): case H_(bf875611,200e9990):  /* vector_size */
+      case LJ_KS_vector_size: case LJ_KS___vector_size__:  /* vector_size */
 	{
 	  CTSize vsize = cp_decl_sizeattr(cp);
 	  if (vsize) CTF_INSERT(decl->attr, VSIZEP, lj_fls(vsize));
 	}
 	break;
 #if LJ_TARGET_X86
-      case H_(5ad22db8,c689b848): case H_(439150fa,65ea78cb):  /* regparm */
+      case LJ_KS_regparm: case LJ_KS___regparm__:  /* regparm */
 	CTF_INSERT(decl->fattr, REGPARM, cp_decl_sizeattr(cp));
 	decl->fattr |= CTFP_CCONV;
 	break;
-      case H_(18fc0b98,7ff4c074): case H_(4e62abed,0a747424):  /* cdecl */
+      case LJ_KS_cdecl: case LJ_KS___cdecl__:  /* cdecl */
 	CTF_INSERT(decl->fattr, CCONV, CTCC_CDECL);
 	decl->fattr |= CTFP_CCONV;
 	break;
-      case H_(72b2e41b,494c5a44): case H_(f2356d59,f25fc9bd):  /* thiscall */
+      case LJ_KS_thiscall: case LJ_KS___thiscall__:  /* thiscall */
 	CTF_INSERT(decl->fattr, CCONV, CTCC_THISCALL);
 	decl->fattr |= CTFP_CCONV;
 	break;
-      case H_(0d0ffc42,ab746f88): case H_(21c54ba1,7f0ca7e3):  /* fastcall */
+      case LJ_KS_fastcall: case LJ_KS___fastcall__:  /* fastcall */
 	CTF_INSERT(decl->fattr, CCONV, CTCC_FASTCALL);
 	decl->fattr |= CTFP_CCONV;
 	break;
-      case H_(ef76b040,9412e06a): case H_(de56697b,c750e6e1):  /* stdcall */
+      case LJ_KS_stdcall: case LJ_KS___stdcall__:  /* stdcall */
 	CTF_INSERT(decl->fattr, CCONV, CTCC_STDCALL);
 	decl->fattr |= CTFP_CCONV;
 	break;
-      case H_(ea78b622,f234bd8e): case H_(252ffb06,8d50f34b):  /* sseregparm */
+      case LJ_KS_sseregparm: case LJ_KS___sseregparm__:  /* sseregparm */
 	decl->fattr |= CTF_SSEREGPARM;
 	decl->fattr |= CTFP_CCONV;
 	break;
@@ -1128,8 +1127,8 @@ static void cp_decl_msvcattribute(CPState *cp, CPDecl *decl)
   while (cp->tok == CTOK_IDENT) {
     GCstr *attrstr = cp->str;
     cp_next(cp);
-    switch (attrstr->hash) {
-    case H_(bc2395fa,98f267f8):  /* align */
+    switch (lj_ks(attrstr)) {
+    case LJ_KS_align:
       cp_decl_align(cp, decl);
       break;
     default:  /* Ignore all other attributes. */
@@ -1718,16 +1717,17 @@ static void cp_pragma(CPState *cp, BCLine pragmaline)
 {
   cp_next(cp);
   if (cp->tok == CTOK_IDENT &&
-      cp->str->hash == H_(e79b999f,42ca3e85))  {  /* pack */
+      lj_ks(cp->str) == LJ_KS_pack)  {  /* pack */
     cp_next(cp);
     cp_check(cp, '(');
     if (cp->tok == CTOK_IDENT) {
-      if (cp->str->hash == H_(738e923c,a1b65954)) {  /* push */
+      MSize hsh = lj_ks(cp->str);
+      if (hsh == LJ_KS_push) {  /* push */
 	if (cp->curpack < CPARSE_MAX_PACKSTACK) {
 	  cp->packstack[cp->curpack+1] = cp->packstack[cp->curpack];
 	  cp->curpack++;
 	}
-      } else if (cp->str->hash == H_(6c71cf27,6c71cf27)) {  /* pop */
+      } else if (hsh == LJ_KS_pop) {  /* pop */
 	if (cp->curpack > 0) cp->curpack--;
       } else {
 	cp_errmsg(cp, cp->tok, LJ_ERR_XSYMBOL);
@@ -1777,12 +1777,12 @@ static void cp_decl_multi(CPState *cp)
 	cp_line(cp, hashline);
 	continue;
       } else if (tok == CTOK_IDENT &&
-		 cp->str->hash == H_(187aab88,fcb60b42)) { /* line */
+		 lj_ks(cp->str) == LJ_KS_line) { /* line */
 	if (cp_next(cp) != CTOK_INTEGER) cp_err_token(cp, tok);
 	cp_line(cp, hashline);
 	continue;
       } else if (tok == CTOK_IDENT &&
-	  cp->str->hash == H_(f5e6b4f8,1d509107)) { /* pragma */
+	  lj_ks(cp->str) == LJ_KS_pragma) { /* pragma */
 	cp_pragma(cp, hashline);
 	continue;
       } else {

--- a/src/lj_known_strings.h
+++ b/src/lj_known_strings.h
@@ -1,0 +1,51 @@
+#ifndef LJ_KNOWN_STRINGS_H
+#define LJ_KNOWN_STRINGS_H
+/* small hash function for lj_cparse.c and lib_ffi.c */
+static LJ_AINLINE uint32_t lj_ks(GCstr* s)
+{
+  uint32_t h = 0;
+  const uint8_t* v = (const uint8_t*)strdata(s);
+  /* do not use s->len for loop cause clang produces bad code then */
+  for (; *v; v++) {
+    h = h*9 + *v;
+    h = lj_rol(h, 7);
+  }
+  return h;
+}
+#define LJ_KS_32bit	0x01555882
+#define LJ_KS_64bit	0x21558175
+#define LJ_KS___aligned__	0x569f93c0
+#define LJ_KS___cdecl__	0xd9fd5be2
+#define LJ_KS___fastcall__	0xa9df7119
+#define LJ_KS___mode__	0x9fcb48c2
+#define LJ_KS___packed__	0xd3c4c96f
+#define LJ_KS___regparm__	0x5f530d2e
+#define LJ_KS___sseregparm__	0x7f8cef82
+#define LJ_KS___stdcall__	0x1b3e9db8
+#define LJ_KS___thiscall__	0xb007f754
+#define LJ_KS___vector_size__	0x45505b8d
+#define LJ_KS_align	0xe845f6c4
+#define LJ_KS_aligned	0xc5e4d088
+#define LJ_KS_be	0x00dcb280
+#define LJ_KS_cdecl	0x3fbc4f68
+#define LJ_KS_eabi	0xa6fcc27d
+#define LJ_KS_fastcall	0xee79726d
+#define LJ_KS_fpu	0x09bc3a84
+#define LJ_KS_gc64	0xdad9ac58
+#define LJ_KS_hardfp	0x825f5c57
+#define LJ_KS_le	0x00f33280
+#define LJ_KS_line	0xe817c4bc
+#define LJ_KS_mode	0xb4c144ea
+#define LJ_KS_pack	0xd6ff07f2
+#define LJ_KS_packed	0x61c931ac
+#define LJ_KS_pop	0x6ef9f804
+#define LJ_KS_pragma	0x196f8b59
+#define LJ_KS_push	0xa1a30673
+#define LJ_KS_regparm	0xdbe7ffae
+#define LJ_KS_softfp	0x6db65aa5
+#define LJ_KS_sseregparm	0xdd0742dd
+#define LJ_KS_stdcall	0xefb972d6
+#define LJ_KS_thiscall	0xa729bb14
+#define LJ_KS_vector_size	0x639def61
+#define LJ_KS_win	0xb5cc7704
+#endif


### PR DESCRIPTION
Add small string hash function, so lj_parse.c and lib.ffi.c do not depends on hash calculated in lj_str_new.

This will allow embedders to easier switch hashsum algorithm in lj_str_new if they wants.