### PR TITLE
Expose function prototype via funcinfo()

### DIFF
--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -199,6 +199,7 @@ LJLIB_CF(jit_util_funcinfo)
     lua_setfield(L, -2, "source");
     lj_debug_pushloc(L, pt, pc);
     lua_setfield(L, -2, "loc");
+    setprotoV(L, lj_tab_setstr(L, t, lj_str_newlit(L, "proto")), pt);
   } else {
     GCfunc *fn = funcV(L->base);
     GCtab *t;


### PR DESCRIPTION
Expose function prototype via funcinfo() in jit.util.

The feature is convenient for trace visualisers like https://github.com/mejedi/luajit-web-inspector. Using linedefined/source for this purpose is less reliable.