### PR TITLE
Fixed jit (bytecode save) elf header flags for mips

### DIFF
--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -239,7 +239,7 @@ typedef struct {
   hdr.type = f16(1)
   hdr.machine = f16(({ x86=3, x64=62, arm=40, ppc=20, ppcspe=20, mips=8, mipsel=8 })[ctx.arch])
   if ctx.arch == "mips" or ctx.arch == "mipsel" then
-    hdr.flags = 0x50001006
+    hdr.flags = f32(0x50001006) -- EF_MIPS_ARCH_32|E_MIPS_ABI_O32|EF_MIPS_CPIC|EF_MIPS_PIC
   end
   hdr.version = f32(1)
   hdr.shofs = fofs(ffi.offsetof(o, "sect"))


### PR DESCRIPTION
Only occurs when host endianness differs from target (in this case most do)