### PR TITLE
take next() out of the NYI list

### DIFF
--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -75,7 +75,7 @@ LJLIB_ASM_(type)		LJLIB_REC(.)
 /* This solves a circular dependency problem -- change FF_next_N as needed. */
 LJ_STATIC_ASSERT((int)FF_next == FF_next_N);
 
-LJLIB_ASM(next)
+LJLIB_ASM(next)			LJLIB_REC(.)
 {
   lj_lib_checktab(L, 1);
   return FFH_UNREACHABLE;

--- a/src/lib_table.c
+++ b/src/lib_table.c
@@ -40,9 +40,12 @@ LJLIB_LUA(table_foreach) /*
   function(t, f)
     CHECK_tab(t)
     CHECK_func(f)
-    for k, v in PAIRS(t) do
+    local next = next
+    local k, v = next(t)
+    while k ~= nil do
       local r = f(k, v)
       if r ~= nil then return r end
+      k, v = next(t, k)
     end
   end
 */

--- a/src/lj_asm.c
+++ b/src/lj_asm.c
@@ -1685,7 +1685,7 @@ static void asm_ir(ASMState *as, IRIns *ir)
   case IR_LREF: asm_lref(as, ir); break;
 
   /* Loads and stores. */
-  case IR_ALOAD: case IR_HLOAD: case IR_ULOAD: case IR_VLOAD:
+  case IR_ALOAD: case IR_HLOAD: case IR_ULOAD: case IR_VLOAD: case IR_HKLOAD:
     asm_ahuvload(as, ir);
     break;
   case IR_FLOAD: asm_fload(as, ir); break;

--- a/src/lj_asm_x86.h
+++ b/src/lj_asm_x86.h
@@ -1523,6 +1523,7 @@ static void asm_ahuvload(ASMState *as, IRIns *ir)
     RegSet allow = irt_isnum(ir->t) ? RSET_FPR : RSET_GPR;
     Reg dest = ra_dest(as, ir, allow);
     asm_fuseahuref(as, ir->op1, RSET_GPR);
+    if (ir->o == IR_HKLOAD) as->mrm.ofs += offsetof(Node, key);
 #if LJ_GC64
     if (irt_isaddr(ir->t)) {
       emit_shifti(as, XOg_SHR|REX_64, dest, 17);
@@ -1550,6 +1551,7 @@ static void asm_ahuvload(ASMState *as, IRIns *ir)
     }
 #endif
     asm_fuseahuref(as, ir->op1, gpr);
+    if (ir->o == IR_HKLOAD) as->mrm.ofs += offsetof(Node, key);
   }
   /* Always do the type check, even if the load result is unused. */
   as->mrm.ofs += 4;

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -415,6 +415,25 @@ static void LJ_FASTCALL recff_tostring(jit_State *J, RecordFFData *rd)
   }
 }
 
+static void LJ_FASTCALL recff_next(jit_State *J, RecordFFData *rd)
+{
+  RecordIndex ix;
+  ix.tab = J->base[0]; ix.key = J->base[1];
+  if (tref_istab(ix.tab)) {
+    ix.val = 0; ix.idxchain = 0;
+    settabV(J->L, &ix.tabv, tabV(&rd->argv[0]));
+    copyTV(J->L, &ix.keyv, &rd->argv[1]);
+
+    if (lj_record_next(J, &ix)) {
+      rd->nres = 2;
+      J->base[0] = ix.key;
+      J->base[1] = ix.val;
+    } else {
+      recff_nyiu(J, rd);
+    }
+  } /* not a table, interepreter should throw. */
+}
+
 static void LJ_FASTCALL recff_ipairs_aux(jit_State *J, RecordFFData *rd)
 {
   RecordIndex ix;

--- a/src/lj_ir.h
+++ b/src/lj_ir.h
@@ -107,6 +107,7 @@
   _(XLOAD,	L , ref, lit) \
   _(SLOAD,	L , lit, lit) \
   _(VLOAD,	L , ref, ___) \
+  _(HKLOAD,	L , ref, ___) \
   \
   _(ASTORE,	S , ref, ref) \
   _(HSTORE,	S , ref, ref) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -153,6 +153,8 @@ typedef struct CCallInfo {
   _(ANY,	lj_tab_clear,		1,  FS, NIL, 0) \
   _(ANY,	lj_tab_newkey,		3,   S, PGC, CCI_L) \
   _(ANY,	lj_tab_len,		1,  FL, INT, 0) \
+  _(ANY,	lj_tab_nexta,		2,  FL, INT, 0) \
+  _(ANY,	lj_tab_nexth,		3,  FL, PGC, CCI_L) \
   _(ANY,	lj_gc_step_jit,		2,  FS, NIL, CCI_L) \
   _(ANY,	lj_gc_barrieruv,	2,  FS, NIL, 0) \
   _(ANY,	lj_mem_newgco,		2,  FS, PGC, CCI_L) \

--- a/src/lj_record.h
+++ b/src/lj_record.h
@@ -38,6 +38,8 @@ LJ_FUNC void lj_record_ret(jit_State *J, BCReg rbase, ptrdiff_t gotresults);
 LJ_FUNC int lj_record_mm_lookup(jit_State *J, RecordIndex *ix, MMS mm);
 LJ_FUNC TRef lj_record_idx(jit_State *J, RecordIndex *ix);
 
+LJ_FUNC int lj_record_next(jit_State *J, RecordIndex *ix);
+
 LJ_FUNC void lj_record_ins(jit_State *J);
 LJ_FUNC void lj_record_setup(jit_State *J);
 #endif

--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -594,6 +594,29 @@ static uint32_t keyindex(lua_State *L, GCtab *t, cTValue *key)
   return ~0u;  /* A nil key starts the traversal. */
 }
 
+
+/* Get the next array index */
+MSize LJ_FASTCALL lj_tab_nexta(GCtab *t, MSize k)
+{
+  for (k++; k < t->asize; k++)
+    if (!tvisnil(arrayslot(t, k)))
+      break;
+  return k;
+}
+
+
+LJ_FUNCA cTValue *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n)
+{
+  const Node *nodeend = noderef(t->node)+t->hmask;
+  for (n++; n <= nodeend; n++) {
+    if (!tvisnil(&n->val)) {
+      return &n->key;
+    }
+  }
+  return niltv(L);
+}
+
+
 /* Advance to the next step in a table traversal. */
 int lj_tab_next(lua_State *L, GCtab *t, TValue *key)
 {

--- a/src/lj_tab.c
+++ b/src/lj_tab.c
@@ -605,15 +605,15 @@ MSize LJ_FASTCALL lj_tab_nexta(GCtab *t, MSize k)
 }
 
 
-LJ_FUNCA cTValue *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n)
+LJ_FUNCA const Node *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n)
 {
   const Node *nodeend = noderef(t->node)+t->hmask;
   for (n++; n <= nodeend; n++) {
     if (!tvisnil(&n->val)) {
-      return &n->key;
+      return n;
     }
   }
-  return niltv(L);
+  return &G(L)->nilnode;
 }
 
 

--- a/src/lj_tab.h
+++ b/src/lj_tab.h
@@ -68,7 +68,7 @@ LJ_FUNC TValue *lj_tab_set(lua_State *L, GCtab *t, cTValue *key);
   (inarray((t), (key)) ? arrayslot((t), (key)) : lj_tab_setinth(L, (t), (key)))
 
 LJ_FUNCA MSize LJ_FASTCALL lj_tab_nexta(GCtab *t, MSize k);
-LJ_FUNCA cTValue *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n);
+LJ_FUNCA const Node *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n);
 LJ_FUNCA int lj_tab_next(lua_State *L, GCtab *t, TValue *key);
 LJ_FUNCA MSize LJ_FASTCALL lj_tab_len(GCtab *t);
 

--- a/src/lj_tab.h
+++ b/src/lj_tab.h
@@ -67,6 +67,8 @@ LJ_FUNC TValue *lj_tab_set(lua_State *L, GCtab *t, cTValue *key);
 #define lj_tab_setint(L, t, key) \
   (inarray((t), (key)) ? arrayslot((t), (key)) : lj_tab_setinth(L, (t), (key)))
 
+LJ_FUNCA MSize LJ_FASTCALL lj_tab_nexta(GCtab *t, MSize k);
+LJ_FUNCA cTValue *LJ_FASTCALL lj_tab_nexth(lua_State *L, GCtab *t, const Node *n);
 LJ_FUNCA int lj_tab_next(lua_State *L, GCtab *t, TValue *key);
 LJ_FUNCA MSize LJ_FASTCALL lj_tab_len(GCtab *t);
 


### PR DESCRIPTION
It's a little rough on the edges, there are a couple of hacks and one suggestion, but it works and allows `table.foreach()` to be compiled also.
This doesn't improve `pairs()` yet; I think that should be optimized separately.
The hacks are around the `HREF`/`HLOAD` IR instruction pair; as I understand it, `HREF` returns a pointer to a value slot in the table, and `HLOAD` does a simple dereference on that pointer.  This patch assumes that pointer can be cast to a `Node *`, so the `HREF` is used instead of a call to `keyindex()`. And to return the key without having to specialize on type, it returns a pointer to it, and uses an `HLOAD` to actually fetch that key (not the value).
So, I'd like to formalize the return of `HREF` as a key/value pair reference, rename `HLOAD` to `HVLOAD` and add a `HKLOAD` instruction to load the key from that pair.  Then the IR for this would be reduced to:
```
HREF tab, key
CALL lj_tab_nexth (tab, href)
HKLOAD callref
HVLOAD callref
```
and avoid the repeated table query.