### PR TITLE
Fixes #282: Incorrect range calculation in mcode_alloc()

### DIFF
--- a/src/lj_mcode.c
+++ b/src/lj_mcode.c
@@ -244,9 +244,9 @@ static void *mcode_alloc(jit_State *J, size_t sz)
     }
     /* Next try probing pseudo-random addresses. */
     do {
-      hint = (0x78fb ^ LJ_PRNG_BITS(J, 15)) << 16;  /* 64K aligned. */
-    } while (!(hint + sz < range));
-    hint = target + hint - (range>>1);
+      hint = LJ_PRNG_BITS(J, LJ_TARGET_JUMPRANGE-16) << 16;  /* 64K aligned. */
+    } while (!(hint + sz < range*2));
+    hint = target + hint - range;
   }
   lj_trace_err(J, LJ_TRERR_MCODEAL);  /* Give up. OS probably ignores hints? */
   return NULL;


### PR DESCRIPTION
Since 'range' in mcode_alloc() is calculated based on
LJ_TARGET_JUMPRANGE-1, i.e. already half the available jump range, don't
divide it by 2 again for randomized allocations.

Also fix the number of bits argument to LJ_PRNG_BITS() to not generate
excessive bits on architectures with LJ_TARGET_JUMPRANGE < 31. That
wouldn't play well with the 0x78b constant being XORed with the
generated random number apparently to improve PRNG properties, so that
part has been removed. Improving PRNG will be addressed separately.