### PR TITLE
VMProfile: less-is-more profiler backend

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -481,7 +481,7 @@ LJLIB_C= $(LJLIB_O:.o=.c)
 LJCORE_O= lj_gc.o lj_err.o lj_char.o lj_bc.o lj_obj.o lj_buf.o \
 	  lj_str.o lj_tab.o lj_func.o lj_udata.o lj_meta.o lj_debug.o \
 	  lj_state.o lj_dispatch.o lj_vmevent.o lj_vmmath.o lj_strscan.o \
-	  lj_strfmt.o lj_strfmt_num.o lj_api.o lj_profile.o \
+	  lj_strfmt.o lj_strfmt_num.o lj_api.o lj_profile.o lj_vmprofile.o \
 	  lj_lex.o lj_parse.o lj_bcread.o lj_bcwrite.o lj_load.o \
 	  lj_ir.o lj_opt_mem.o lj_opt_fold.o lj_opt_narrow.o \
 	  lj_opt_dce.o lj_opt_loop.o lj_opt_split.o lj_opt_sink.o \

--- a/src/lib_jit.c
+++ b/src/lib_jit.c
@@ -630,6 +630,34 @@ static int luaopen_jit_profile(lua_State *L)
 
 #endif
 
+/* -- jit.vmprofile module  ----------------------------------------------- */
+
+#ifdef LUAJIT_VMPROFILE
+
+#define LJLIB_MODULE_jit_vmprofile
+
+LJLIB_CF(jit_vmprofile_start)
+{
+  luaJIT_vmprofile_start(L);
+  return 0;
+}
+
+LJLIB_CF(jit_vmprofile_stop)
+{
+  luaJIT_vmprofile_stop(L);
+  return 0;
+}
+
+#include "lj_libdef.h"
+
+static int luaopen_jit_vmprofile(lua_State *L)
+{
+  LJ_LIB_REG(L, NULL, jit_vmprofile);
+  return 1;
+}
+
+#endif
+
 /* -- JIT compiler initialization ----------------------------------------- */
 
 #if LJ_HASJIT
@@ -764,6 +792,10 @@ LUALIB_API int luaopen_jit(lua_State *L)
 #if LJ_HASPROFILE
   lj_lib_prereg(L, LUA_JITLIBNAME ".profile", luaopen_jit_profile,
 		tabref(L->env));
+#endif
+#ifdef LUAJIT_VMPROFILE
+  lj_lib_prereg(L, LUA_JITLIBNAME ".vmprofile", luaopen_jit_vmprofile,
+                tabref(L->env));
 #endif
 #ifndef LUAJIT_DISABLE_JITUTIL
   lj_lib_prereg(L, LUA_JITLIBNAME ".util", luaopen_jit_util, tabref(L->env));

--- a/src/lj_vmprofile.c
+++ b/src/lj_vmprofile.c
@@ -1,0 +1,113 @@
+/*
+** VM profiling.
+** Copyright (C) 2016 Luke Gorrie. See Copyright Notice in luajit.h
+*/
+
+#define lj_vmprofile_c
+#define LUA_CORE
+
+#ifdef LUAJIT_VMPROFILE
+
+#define _GNU_SOURCE 1
+#include <stdio.h>
+#include <assert.h>
+#include <sys/time.h>
+#include <stdint.h>
+#include <signal.h>
+#include <ucontext.h>
+#undef _GNU_SOURCE
+
+#include "lj_obj.h"
+#include "lj_dispatch.h"
+#include "lj_jit.h"
+#include "lj_trace.h"
+#include "lj_vmprofile.h"
+
+static struct {
+  global_State *g;
+  struct sigaction oldsa;
+} state;
+
+/* -- State that the application can manage via FFI ----------------------- */
+
+static VMProfile *profile;      /* Current counters */
+
+/* How much memory to allocate for profiler counters. */
+int vmprofile_get_profile_size() {
+  return sizeof(VMProfile);
+}
+
+/* Set the memory where the next samples will be counted. 
+   Size of the memory must match vmprofile_get_profile_size(). */
+void vmprofile_set_profile(void *counters) {
+  profile = (VMProfile*)counters;
+  profile->magic = 0x1d50f007;
+  profile->major = 1;
+  profile->minor = 0;
+}
+
+/* -- Signal handler ------------------------------------------------------ */
+
+/* Signal handler: bumps one counter. */
+static void vmprofile_signal(int sig, siginfo_t *si, void *data)
+{
+  if (profile != NULL) {
+    lua_State *L = gco2th(gcref(state.g->cur_L));
+    int vmstate = state.g->vmstate;
+    /* Not in a trace */
+    if (vmstate < 0) {
+      profile->vm[~vmstate]++;
+    } else {
+      int bucket = vmstate > LJ_VMPROFILE_TRACE_MAX ? 0 : vmstate;
+      VMProfileTraceCount *count = &profile->trace[bucket];
+      GCtrace *T = traceref(L2J(L), (TraceNo)vmstate);
+      intptr_t ip = (intptr_t)((ucontext_t*)data)->uc_mcontext.gregs[REG_RIP];
+      ptrdiff_t mcposition = ip - (intptr_t)T->mcode;
+      if ((mcposition < 0) || (mcposition >= T->szmcode)) {
+        count->other++;
+      } else if ((T->mcloop != 0) && (mcposition >= T->mcloop)) {
+        count->loop++;
+      } else {
+        count->head++;
+      }
+    }
+  }
+}
+
+static void start_timer(int interval)
+{
+  struct itimerval tm;
+  struct sigaction sa;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = interval / 1000;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = (interval % 1000) * 1000;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sa.sa_flags = SA_SIGINFO | SA_RESTART;
+  sa.sa_sigaction = vmprofile_signal;
+  sigemptyset(&sa.sa_mask);
+  sigaction(SIGPROF, &sa, &state.oldsa);
+}
+
+static void stop_timer()
+{
+  struct itimerval tm;
+  tm.it_value.tv_sec = tm.it_interval.tv_sec = 0;
+  tm.it_value.tv_usec = tm.it_interval.tv_usec = 0;
+  setitimer(ITIMER_PROF, &tm, NULL);
+  sigaction(SIGPROF, NULL, &state.oldsa);
+}
+
+/* -- Lua API ------------------------------------------------------------- */
+
+LUA_API void luaJIT_vmprofile_start(lua_State *L)
+{
+  memset(&state, 0, sizeof(state));
+  state.g = G(L);
+  start_timer(1);               /* Sample every 1ms */
+}
+
+LUA_API void luaJIT_vmprofile_stop(lua_State *L)
+{
+  stop_timer();
+}
+
+#endif

--- a/src/lj_vmprofile.h
+++ b/src/lj_vmprofile.h
@@ -1,0 +1,37 @@
+/*
+** Virtual machine profiling.
+** Copyright (C) 2017 Luke Gorrie. See Copyright Notice in luajit.h
+*/
+
+#ifndef _LJ_VMPROFILE_H
+#define _LJ_VMPROFILE_H
+
+
+/* Counters are 64-bit to avoid overflow even in long running processes. */
+typedef uint64_t VMProfileCount;
+
+/* Maximum trace number for distinct counter buckets. Traces with
+   higher numbers will be counted together in bucket zero. */
+#define LJ_VMPROFILE_TRACE_MAX 4096
+
+/* Traces have separate counters for different machine code regions. */
+typedef struct VMProfileTraceCount {
+  VMProfileCount head;          /* Head of the trace (non-looping part) */
+  VMProfileCount loop;          /* Loop of the trace */
+  VMProfileCount other;         /* Outside the trace mcode (unidentified) */
+} VMProfileTraceCount;
+
+/* Complete set of counters for VM and traces. */
+typedef struct VMProfile {
+  uint32_t magic;               /* 0x1d50f007 */
+  uint16_t major, minor;        /* 1, 0 */
+  VMProfileCount vm[LJ_VMST__MAX];
+  VMProfileTraceCount trace[LJ_VMPROFILE_TRACE_MAX+1];
+} VMProfile;
+
+/* Functions that should be accessed via FFI. */
+
+void vmprofile_set_profile(void *counters);
+int vmprofile_get_profile_size();
+
+#endif

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -73,6 +73,10 @@ LUA_API void luaJIT_profile_stop(lua_State *L);
 LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
 					     int depth, size_t *len);
 
+/* VM profiling API. */
+LUA_API void luaJIT_vmprofile_start(lua_State *L);
+LUA_API void luaJIT_vmprofile_stop(lua_State *L);
+
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 


### PR DESCRIPTION
_This is currently weekend-hack status, early feedback welcome!_

VMProfile is a minimalist LuaJIT virtual machine profiler for use with production systems. It has very low overhead and it makes minimal assumptions about when, where, and how its data will be analyzed.

VMProfile provides a write-only API for recording profiler data into memory. It is designed for inspection rather than introspection: it assumes the data will be interpreted by other tools that may be running in other processes, written in other languages, running on other machines, etc.

The profiler samples the virtual machine state and CPU instruction pointer once per millisecond. Each sample bumps one counter in memory. Separate counters are defined for:

- VM states: interpreting, garbage collecting, assembling, etc.
- JIT traces 1-4096: each trace has a `head` counter for the pre-loop machine code, a `loop` counter for the machine code loop (when applicable), and a `foreign` counter for executing code that is not part of the trace mcode (e.g. FFI calls.)
- JIT trace 0 is used as a catch-all for other traces.

### API

You can turn sampling on and off using a Lua API:

```lua
vmprofile = require("jit.vmprofile")
vmprofile.start() -- Start sampling with 1kHz itimer
vmprofile.stop()  -- Stop the sampling timer.
```

Samples will be discarded unless a buffer is provided. FFI can be used to supply a buffer of the appropriate size. The buffer can be switched at any time to implement multiple profiler regions (like `jit.zone`.)

```c
/* Return the amount of memory required for profiler counters. */
int vmprofile_get_profile_size();
/* Set the current memory region to count into (or NULL to disable. */
void vmprofile_set_profile(void *counters);
```

Storing and decoding the profiler data is outside the scope of this API. The user is assumed to provide memory that will be accessible (e.g. file-backed shared memory) and to create tools that understand the data (referencing the layout in `lj_vmprofile.h` directly.)

### Self-profiling program example

Below is an example of a self-profiling program. This program enables profiling, uses ljsyscall to allocate several sets of profiler counters in persistent file-backed shared memory, and runs some standard LuaJIT benchmarks with separate profiles. The JIT dump is recorded for reference. Because the profiler counters are allocated in file-backed shared memory they can be examined both in real-time while the process runs and offline after it terminates.

```lua
-- Setup JIT dumping  --------------------------------------                                                                                                                                                       

require("jit.dump").start("+r", "jitdump.txt")

-- Load modules                                                                                                                                                                                                    

local ffi = require("ffi")
local C   = ffi.C
package.path = 'ljsyscall/?.lua;' .. package.path
local S   = require("ljsyscall/syscall")

-- Setup profiling -----------------------------------------                                                                                                                                                       

-- Start sampling.                                                                                                                                                                                                 
local vmprofile = require("jit.vmprofile")
vmprofile.start()

-- FFI interface towards vmprofile                                                                                                                                                                                 
ffi.cdef[[                                                                                                                                                                                                         
int vmprofile_get_profile_size();                                                                                                                                                                                  
void vmprofile_set_profile(void *counters);                                                                                                                                                                        
]]

-- Allocate profile counters in file-backed shared memory.                                                                                                                                                         
local function vmprofile_alloc (filename)
   local fd = S.open(filename, "rdwr,creat,trunc", "rwxu")
   local sz = C.vmprofile_get_profile_size()
   assert((fd:truncate(sz)))
   local ptr = assert((fd:mmap(nil, sz, "read, write", "shared", 0)))
   return ffi.gc(ptr, nil) -- don't automatically free                                                                                                                                                             
end

-- Run benchmarks ------------------------------------------                                                                                                                                                       

C.vmprofile_set_profile(vmprofile_alloc("series.vmprofile"))
arg = {20000}
dofile("luajit-test-cleanup/bench/series.lua")

C.vmprofile_set_profile(vmprofile_alloc("md5.vmprofile"))
arg = {100000}
dofile("luajit-test-cleanup/bench/md5.lua")

C.vmprofile_set_profile(vmprofile_alloc("coroutine-ring.vmprofile"))
arg = {1e8}
dofile("luajit-test-cleanup/bench/coroutine-ring.lua")

C.vmprofile_set_profile(vmprofile_alloc("nbody.vmprofile"))
arg = {1e7}
dofile("luajit-test-cleanup/bench/nbody.lua")

C.vmprofile_set_profile(vmprofile_alloc("spectral-norm.vmprofile"))
arg = {5000}
dofile("luajit-test-cleanup/bench/spectral-norm.lua")
```

### vmprofiler: a profile analyzer

[vmprofiler](https://github.com/studio/vmprofiler) is an R program for analyzing vmprofile data. Currently it supports some simple numeric analysis. In the future it could be extended to summarize the execution of hundreds of processes in sophisticated ways.

Show the relative amount of samples recorded (time spent) between a set of vmprofiles:

```
$ vmprofiler profile *.vmprofile
        profile percent
            md5    28.5
  spectral-norm    20.9
 coroutine-ring    19.4
         series    19.2
          nbody    12.0
```

Show a breakdown of individual virtual machine states and regions of traces:

```
$ vmprofiler where *.vmprofile
        profile     where percent
 coroutine-ring    interp    14.1
 coroutine-ring   head.16     2.3
 coroutine-ring    head.9     1.1
            md5    head.3    20.3
            md5   loop.10     5.5
            md5 foreign.5     1.7
          nbody   head.21     5.7
          nbody   loop.21     3.7
          nbody   head.22     1.5
          nbody   head.23     1.0
         series foreign.6     9.3
         series foreign.5     9.1
  spectral-norm    loop.4    10.4
  spectral-norm   loop.25    10.4
```

This report can be used to identify the most relevant parts of the [jitdump.txt](https://gist.github.com/lukego/46543642293853017a392f14df89f759) file.

### Future

VMProfile is one part of an effort to write more comprehensive tooling for LuaJIT development. The next step is a version of `jit.dump` that writes the complete raw internal data structures to a binary log and is efficient enough to keep enabled in production, followed by tooling for interactively examining these dumps. (This is also related to _timeline logs_ in Snabb for precise cycle counting at the application level.)

The major requirement of my efforts it that the tooling should always be available for examining production systems including network equipment with realtime constratins (Snabb.) This is leading towards new tools that make raw data available to external analysis tools, rather than introspective tools that need to run inside the system being examined (e.g. `jit.v`, `jit.dump`, `jit.profile`, etc.) It would be awesome if other people are interested in these requirements too!