### PR TITLE
Fix severe slowdown on certain strings

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -148,6 +148,10 @@ XCFLAGS=
 # everything. Use only if you suspect a problem with LuaJIT itself.
 #XCFLAGS+= -DLUA_USE_ASSERT
 #
+# Switch to harder (and slower) hash function when a collision chain in
+# the string hash table exceeds certain length.
+XCFLAGS+= -DLUAJIT_SMART_STRINGS=1
+#
 ##############################################################################
 # You probably don't need to change anything below this line!
 ##############################################################################


### PR DESCRIPTION
The default "fast" string hash function samples only a few positions in
a string, the remaining bytes don't affect the function's result. The
function performs well for short strings; however long strings can yield
extremely high collision rates.

An adaptive schema was implemented. Two hash functions are used
simultaneously. A bucket is picked based on the output of the fast hash
function. If an item is to be inserted in a collision chain longer than
a certain threshold, another bucket is picked based on the stronger hash
function. Since two hash functions are used simultaneously, insert
should consider two buckets. The second bucket is often NOT considered
thanks to the bloom filter. The filter is rebuilt during GC cycle.

In co-authorship with @mejedi ( Nick Zavaritsky <mejedi@gmail.com> )