### PR TITLE
resolve cppcheck finding

### DIFF
--- a/src/host/minilua.c
+++ b/src/host/minilua.c
@@ -3915,7 +3915,7 @@ f->sizelocvars=fs->nlocvars;
 luaM_reallocvector(L,f->upvalues,f->sizeupvalues,f->nups,TString*);
 f->sizeupvalues=f->nups;
 ls->fs=fs->prev;
-if(fs)anchor_token(ls);
+anchor_token(ls);
 L->top-=2;
 }
 static Proto*luaY_parser(lua_State*L,ZIO*z,Mbuffer*buff,const char*name){


### PR DESCRIPTION
[src/host/minilua.c:3902] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3905] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3906] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3907] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3908] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3909] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3910] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3911] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3912] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3913] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3914] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.
[src/host/minilua.c:3917] -> [src/host/minilua.c:3918]: (warning) Either the condition 'if(fs)' is redundant or there is possible null pointer dereference: fs.