### PR TITLE
Correctly report out-of-scope gotos

### DIFF
--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -1282,12 +1282,15 @@ static void fscope_end(FuncState *fs)
       MSize idx = gola_new(ls, NAME_BREAK, VSTACK_LABEL, fs->pc);
       ls->vtop = idx;  /* Drop break label immediately. */
       gola_resolve(ls, bl, idx);
+    } else {
+      /* need the fixup step to propagate the breaks. */
+      gola_fixup(ls, bl);
       return;
-    }  /* else: need the fixup step to propagate the breaks. */
-  } else if (!(bl->flags & FSCOPE_GOLA)) {
-    return;
+    }
   }
-  gola_fixup(ls, bl);
+  if ((bl->flags & FSCOPE_GOLA)) {
+    gola_fixup(ls, bl);
+  }
 }
 
 /* Mark scope as having an upvalue. */


### PR DESCRIPTION
Bug was in `fscope_exit`: if a loop contains a break
[`gola_fixup` will not be called][1] leaving unresolved labels
undetected.  This cannot cause problems for valid code because
`parse_label` [calls `gola_resolve`][2] on each newly parsed label.

Fixes #228.

[1]: https://github.com/LuaJIT/LuaJIT/blob/master/src/lj_parse.c#L1283
[2]: https://github.com/LuaJIT/LuaJIT/blob/master/src/lj_parse.c#L2419