### PR TITLE
add 5.3 operators as syntax sugar

### DIFF
--- a/src/lj_lex.c
+++ b/src/lj_lex.c
@@ -349,10 +349,15 @@ static LexToken lex_scan(LexState *ls, TValue *tv)
       if (ls->c != '=') return '='; else { lex_next(ls); return TK_eq; }
     case '<':
       lex_next(ls);
-      if (ls->c != '=') return '<'; else { lex_next(ls); return TK_le; }
+      if (ls->c == '=') { lex_next(ls); return TK_le; } else
+      if (ls->c == '<') { lex_next(ls); return TK_shl; } else return '<';
     case '>':
       lex_next(ls);
-      if (ls->c != '=') return '>'; else { lex_next(ls); return TK_ge; }
+      if (ls->c == '=') { lex_next(ls); return TK_ge; } else
+      if (ls->c == '>') { lex_next(ls); return TK_shr; } else return '>';
+    case '/':
+      lex_next(ls);
+      if (ls->c != '/') return '/'; else { lex_next(ls); return TK_idiv; }
     case '~':
       lex_next(ls);
       if (ls->c != '=') return '~'; else { lex_next(ls); return TK_ne; }

--- a/src/lj_lex.h
+++ b/src/lj_lex.h
@@ -16,7 +16,8 @@
   _(and) _(break) _(do) _(else) _(elseif) _(end) _(false) \
   _(for) _(function) _(goto) _(if) _(in) _(local) _(nil) _(not) _(or) \
   _(repeat) _(return) _(then) _(true) _(until) _(while) \
-  __(concat, ..) __(dots, ...) __(eq, ==) __(ge, >=) __(le, <=) __(ne, ~=) \
+  __(idiv, idiv) __(concat, ..) __(dots, ...) __(eq, ==) __(ge, >=) __(le, <=) __(ne, ~=) \
+  __(shl, <<) __(shr, >>) \
   __(label, ::) __(number, <number>) __(name, <name>) __(string, <string>) \
   __(eof, <eof>)
 

--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -2034,8 +2034,14 @@ static BinOpr token2binop(LexToken tok)
   case '-':	return OPR_SUB;
   case '*':	return OPR_MUL;
   case '/':	return OPR_DIV;
+  case TK_idiv:	return OPR_IDIV;
   case '%':	return OPR_MOD;
   case '^':	return OPR_POW;
+  case '&':	return OPR_BAND;
+  case '|':	return OPR_BOR;
+  case '~':	return OPR_BXOR;
+  case TK_shl:	return OPR_SHL;
+  case TK_shr:	return OPR_SHR;
   case TK_concat: return OPR_CONCAT;
   case TK_ne:	return OPR_NE;
   case TK_eq:	return OPR_EQ;
@@ -2054,14 +2060,18 @@ static const struct {
   uint8_t left;		/* Left priority. */
   uint8_t right;	/* Right priority. */
 } priority[] = {
-  {6,6}, {6,6}, {7,7}, {7,7}, {7,7},	/* ADD SUB MUL DIV MOD */
-  {10,9}, {5,4},			/* POW CONCAT (right associative) */
+  {10, 10}, {10, 10},			/* ADD SUB */
+  {11, 11}, {11, 11}, {11, 11},		/* MUL DIV MOD */
+  {14, 13}, {9, 8},			/* POW CONCAT (right associative) */
+  {11, 11},				/* IDIV */
+  {6,6}, {4,4}, {5,5},			/* BAND BOR BXOR */
+  {7,7}, {7,7},				/* SHL SHR */
   {3,3}, {3,3},				/* EQ NE */
   {3,3}, {3,3}, {3,3}, {3,3},		/* LT GE GT LE */
   {2,2}, {1,1}				/* AND OR */
 };
 
-#define UNARY_PRIORITY		8  /* Priority for unary operators. */
+#define UNARY_PRIORITY		12  /* Priority for unary operators. */
 
 /* Forward declaration. */
 static BinOpr expr_binop(LexState *ls, ExpDesc *v, uint32_t limit);

--- a/src/lj_parse.c
+++ b/src/lj_parse.c
@@ -149,6 +149,9 @@ typedef struct FuncState {
 typedef enum BinOpr {
   OPR_ADD, OPR_SUB, OPR_MUL, OPR_DIV, OPR_MOD, OPR_POW,  /* ORDER ARITH */
   OPR_CONCAT,
+  OPR_IDIV,
+  OPR_BAND, OPR_BOR, OPR_BXOR,
+  OPR_SHL, OPR_SHR,
   OPR_NE, OPR_EQ,
   OPR_LT, OPR_GE, OPR_LE, OPR_GT,
   OPR_AND, OPR_OR,


### PR DESCRIPTION
At this time, adding new bytecodes in v2.1 is too invasive (see #312 and full discussion in #63).
This implementation of Lua 5.3 operators as syntax sugar is less invasive.
The Lua 5.3 code is transformed like this:
```lua
    ~ a     --> bit.bnot(a)
    a & b   --> bit.band(a, b)
    a | b   --> bit.bor(a, b)
    a ~ b   --> bit.bxor(a, b)
    a << b  --> bit.lshift(a, b)
    a >> b  --> bit.rshift(a, b)
    a // b  --> math.floor(a / b)
```

The limitations are:
- no corresponding metamethods (`__bnot`, `__band`, `__bor`, `__bxor`, `__shl`, `__shr`, `__idiv`)
- error message corresponding to the transformed code (not your source code)
- no constant folding optimization

But the lexicography is compliant with Lua 5.3