### PR TITLE
Add lua_cpcall2 for VA is larger than 47bit

### DIFF
--- a/src/lua.h
+++ b/src/lua.h
@@ -202,6 +202,7 @@ LUA_API int   (lua_setfenv) (lua_State *L, int idx);
 LUA_API void  (lua_call) (lua_State *L, int nargs, int nresults);
 LUA_API int   (lua_pcall) (lua_State *L, int nargs, int nresults, int errfunc);
 LUA_API int   (lua_cpcall) (lua_State *L, lua_CFunction func, void *ud);
+LUA_API int   (lua_cpcall2) (lua_State *L, lua_CFunction func, void *ud);
 LUA_API int   (lua_load) (lua_State *L, lua_Reader reader, void *dt,
                                         const char *chunkname);
 


### PR DESCRIPTION
This pull request is one of 2 proposals for VA is larger than 47bits issue. Please refer https://www.freelists.org/post/luajit/Proposals-for-fixing-light-userdata-issue-on-virtual-address-47-bits-platform for more details.

====

A new API is added to work around issue when VA (virtual address)
is > 47 bit in lua_cpcall API:

  LUA_API int   (lua_cpcall2) (lua_State *L, lua_CFunction func, void *ud);

In new API, the "ud" is wrapped in userdata instead of as lightuserdata
directly. So user's code needs modification to use new API. To get real
user data in "ud", user has to do double de-reference to un-wrap
"ud". e.g.:

  int callback(lua_State *L) {
    int *ud = (int *)lua_touserdata(L, -1);
    *ud = 2;
    return 0;
  }

  needs update to:

  int callback(lua_State *L) {
    int **ud = (int **)lua_touserdata(L, -1);
    **ud = 2;
    return 0;
  }
