### PR TITLE
Don't set rlimit in init_mmap on FreeBSD >= 10.

### DIFF
--- a/src/lj_alloc.c
+++ b/src/lj_alloc.c
@@ -343,7 +343,7 @@ static void *CALL_MMAP(size_t size)
 }
 #endif
 
-#if (defined(__FreeBSD__) || defined(__FreeBSD_kernel__)) && !LJ_TARGET_PS4
+#if ((defined(__FreeBSD__) && __FreeBSD__ < 10) || defined(__FreeBSD_kernel__)) && !LJ_TARGET_PS4
 
 #include <sys/resource.h>
 


### PR DESCRIPTION
FreeBSD 10 and above support the MAP_32BIT flag to mmap.