### PR TITLE
Document 47 bit limit for lightuserdata.

### DIFF
--- a/doc/status.html
+++ b/doc/status.html
@@ -95,6 +95,17 @@ handled correctly. The error may fall through an on-trace
 <tt>lua_atpanic</tt> on x64. This issue will be fixed with the new
 garbage collector.
 </li>
+<li>
+LuaJIT on 64 bit systems provides a <b>limited range</b> of 47 bits for the
+<b>legacy <tt>lightuserdata</tt></b> data type.
+This is only relevant on x64 systems which use the negative part of the
+virtual address space in user mode, e.g. Solaris/x64, and on ARM64 systems
+configured with a 48 bit or 52 bit VA.
+Avoid using <tt>lightuserdata</tt> to hold pointers that may point outside
+of that range, e.g. variables on the stack. In general, avoid this data
+type for new code and replace it with (much more performant) FFI bindings.
+FFI cdata pointers can address the full 64 bit range.
+</li>
 </ul>
 <br class="flush">
 </div>


### PR DESCRIPTION
(cherry picked from commit 6538c8a18711a6eb009def36050acd5f02e42aec)

I actually didn't verify that the restriction applies the same as for 2.1, but according to my tests *some* restrictions clearly do apply in 2.0.5, and I think it's better to be aware of them, as [lua 5.1 docs](http://www.lua.org/manual/5.1/manual.html) don't seem to imply any restrictions on the pointer.