### PR TITLE
x64/LJ_GC64: Fix offset in type-check-only SLOAD for non-primitive types

### DIFF
--- a/src/lj_asm_x86.h
+++ b/src/lj_asm_x86.h
@@ -1759,7 +1759,7 @@ static void asm_sload(ASMState *as, IRIns *ir)
       emit_i8(as, irt_toitype(t));
       emit_rr(as, XO_ARITHi8, XOg_CMP, tmp);
       emit_shifti(as, XOg_SAR|REX_64, tmp, 47);
-      emit_rmro(as, XO_MOV, tmp|REX_64, base, ofs+4);
+      emit_rmro(as, XO_MOV, tmp|REX_64, base, ofs);
 #else
     } else {
       emit_i8(as, irt_toitype(t));


### PR DESCRIPTION
Either the `+4` offset should go (as in this commit), or the load and the shift should be narrowed to 32 bits and the shift count reduced from 47 to 15.