### PR TITLE
Ensure the .strtab section written by bcsave.lua is the correct size.

### DIFF
--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -275,7 +275,7 @@ typedef struct {
   o.sect[2].size = fofs(ofs)
   o.sect[3].type = f32(3) -- .strtab
   o.sect[3].ofs = fofs(sofs + ofs)
-  o.sect[3].size = fofs(#symname+1)
+  o.sect[3].size = fofs(#symname+2)
   ffi.copy(o.space+ofs+1, symname)
   ofs = ofs + #symname + 2
   o.sect[4].type = f32(1) -- .rodata


### PR DESCRIPTION
In function `bcsave_elfobj()`, the offset of the `.rodata` section after `.strtab` is already calculated correctly, but the size of `.strtab` itself is one byte too small.  Even though there is a zero byte after the last string in the table, the short size causes lld (the LLVM linker) to show an error message similar to:
```
ld: error: obj/bytecode.o: string table non-null terminated
```
