### PR TITLE
Doc: edit the interpretation of LUAJIT_MODE_OFF

### DIFF
--- a/doc/ext_c_api.html
+++ b/doc/ext_c_api.html
@@ -89,8 +89,8 @@ other Lua/C API functions).
 </p>
 <p>
 The third argument specifies the mode, which is 'or'ed with a flag.
-The flag can be <tt>LUAJIT_MODE_OFF</tt> to turn a feature on,
-<tt>LUAJIT_MODE_ON</tt> to turn a feature off, or
+The flag can be <tt>LUAJIT_MODE_OFF</tt> to turn a feature off,
+<tt>LUAJIT_MODE_ON</tt> to turn a feature on, or
 <tt>LUAJIT_MODE_FLUSH</tt> to flush cached code.
 </p>
 <p>


### PR DESCRIPTION
In the src code:

`
/* Flags or'ed in to the mode. */

#define LUAJIT_MODE_OFF		0x0000	/* Turn feature off. */

#define LUAJIT_MODE_ON		0x0100	/* Turn feature on. */
`

In the doc:

`The flag can be <tt>LUAJIT_MODE_OFF</tt> to turn a feature on`

I guess there's an error in the document.
Thank you.