### PR TITLE
make __eq 5.2 compatible

### DIFF
--- a/src/lj_meta.c
+++ b/src/lj_meta.c
@@ -334,7 +334,7 @@ TValue *lj_meta_equal(lua_State *L, GCobj *o1, GCobj *o2, int ne)
     uint32_t it;
     if (tabref(o1->gch.metatable) != tabref(o2->gch.metatable)) {
       cTValue *mo2 = lj_meta_fast(L, tabref(o2->gch.metatable), MM_eq);
-      if (mo2 == NULL || !lj_obj_equal(mo, mo2))
+      if (mo2 == NULL /*|| !lj_obj_equal(mo, mo2)*/) 
 	return (TValue *)(intptr_t)ne;
     }
     top = curr_top(L);


### PR DESCRIPTION
Regarding issue https://github.com/LuaJIT/LuaJIT/issues/379 (Sorry, I know this issue closed, really need make __eq the same as original lua)

I was able to achieve the same behavior for__eg as lua 5.2. Original Lua not expecting metadata to be exactly the same, like JIT does. 
Can we include this fix or at least for LUAJIT_ENABLE_LUA52COMPAT mode?

Code that works on 5.2 and not in JIT (__eq custom function not triggering):
//Two tables created using this method:
          lua_newtable(l);
    	  lua_newtable(l);        
		
          //push some data for __eq checking ...

           lua_pushcfunction(l, custom_lua_equal);
    	   lua_setfield(l, -2, "__eq"); 

    	   lua_setmetatable(l, -2);