### PR TITLE
Symlink refactor and proper compiler selection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ install: $(INSTALL_DEP)
 	cd src && test -f $(FILE_SO) && \
 	  $(INSTALL_X) $(FILE_SO) $(INSTALL_DYN) && \
 	  $(LDCONFIG) $(INSTALL_LIB) && \
-	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT1) && \
+	  $(SYMLINK) $(INSTALL_SOSHORT2) $(INSTALL_SHORT1) && \
 	  $(SYMLINK) $(INSTALL_SONAME) $(INSTALL_SHORT2) || :
 	cd etc && $(INSTALL_F) $(FILE_MAN) $(INSTALL_MAN)
 	cd etc && $(SED_PC) $(FILE_PC) > $(FILE_PC).tmp && \

--- a/src/Makefile
+++ b/src/Makefile
@@ -27,7 +27,7 @@ NODOTABIVER= 51
 DEFAULT_CC = gcc
 #
 # LuaJIT builds as a native 32 or 64 bit binary by default.
-CC= $(DEFAULT_CC)
+CC?= $(DEFAULT_CC)
 #
 # Use this if you want to force a 32 bit build on a 64 bit multilib OS.
 #CC= $(DEFAULT_CC) -m32


### PR DESCRIPTION
```
libluajit-5.1.so   -> libluajit-5.1.so.2
libluajit-5.1.so.2 -> libluajit-5.1.so.2.1.0
```
instead of
```
libluajit-5.1.so   -> libluajit-5.1.so.2.1.0
libluajit-5.1.so.2 -> libluajit-5.1.so.2.1.0
```
and use `gcc` only if variable `CC` is unset or blank.