### PR TITLE
add luaJIT_compat52 symbol

### DIFF
--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -26,6 +26,8 @@
 #include "lj_strscan.h"
 #include "lj_strfmt.h"
 
+int luaJIT_compat52 = LJ_52;
+
 /* -- Common helper functions --------------------------------------------- */
 
 #define api_checknelems(L, n)		api_check(L, (n) <= (L->top - L->base))

--- a/src/luajit.h
+++ b/src/luajit.h
@@ -76,4 +76,6 @@ LUA_API const char *luaJIT_profile_dumpstack(lua_State *L, const char *fmt,
 /* Enforce (dynamic) linker error for version mismatches. Call from main. */
 LUA_API void LUAJIT_VERSION_SYM(void);
 
+LUA_API int luaJIT_compat52;
+
 #endif


### PR DESCRIPTION
in a C module/extension, this symbol allows to know how luajit was compiled.