### PR TITLE
Fix x86-64 JIT conversion of negative floats to unsigned ints

### DIFF
--- a/src/lj_asm_x86.h
+++ b/src/lj_asm_x86.h
@@ -851,32 +851,38 @@ static void asm_conv(ASMState *as, IRIns *ir)
       asm_tointg(as, ir, ra_alloc1(as, lref, RSET_FPR));
     } else {
       Reg dest = ra_dest(as, ir, RSET_GPR);
+      Reg tmp = ra_noreg(IR(lref)->r) ? ra_alloc1(as, lref, RSET_FPR) :
+					ra_scratch(as, RSET_FPR);
       x86Op op = st == IRT_NUM ? XO_CVTTSD2SI : XO_CVTTSS2SI;
-      if (LJ_64 ? irt_isu64(ir->t) : irt_isu32(ir->t)) {
-	/* LJ_64: For inputs >= 2^63 add -2^64, convert again. */
-	/* LJ_32: For inputs >= 2^31 add -2^31, convert again and add 2^31. */
-	Reg tmp = ra_noreg(IR(lref)->r) ? ra_alloc1(as, lref, RSET_FPR) :
-					  ra_scratch(as, RSET_FPR);
-	MCLabel l_end = emit_label(as);
-	if (LJ_32)
-	  emit_gri(as, XG_ARITHi(XOg_ADD), dest, (int32_t)0x80000000);
-	emit_rr(as, op, dest|REX_64, tmp);
-	if (st == IRT_NUM)
-	  emit_rma(as, XO_ADDSD, tmp, &as->J->k64[LJ_K64_M2P64_31]);
-	else
-	  emit_rma(as, XO_ADDSS, tmp, &as->J->k32[LJ_K32_M2P64_31]);
-	emit_sjcc(as, CC_NS, l_end);
-	emit_rr(as, XO_TEST, dest|REX_64, dest);  /* Check if dest negative. */
-	emit_rr(as, op, dest|REX_64, tmp);
-	ra_left(as, tmp, lref);
-      } else {
-	if (LJ_64 && irt_isu32(ir->t))
-	  emit_rr(as, XO_MOV, dest, dest);  /* Zero hiword. */
-	emit_mrm(as, op,
-		 dest|((LJ_64 &&
-			(irt_is64(ir->t) || irt_isu32(ir->t))) ? REX_64 : 0),
-		 asm_fuseload(as, lref, RSET_FPR));
+      Reg r64 = (LJ_64 && irt_is64 (ir->t)) ? REX_64 : 0;
+      if (LJ_64 && (irt_isu32(ir->t) || irt_isint(ir->t)))
+	emit_rr(as, XO_MOV, dest, dest);  /* Zero hiword. */
+      if (irt_isu64(ir->t) || irt_isu32(ir->t)) {
+        /* The cvtsd2si family of instructions operates on the signed integers,
+           producing INT_MIN on error.  However we're converting to an unsigned
+           integer, so we want to accept the whole unsigned integer range.
+           Convert both the number and the number minus INT_MIN, choosing the
+           first result if successful and the second otherwise.  */
+        Reg dest2 = ra_scratch(as, rset_exclude(RSET_GPR, dest));
+        Reg tmp2 = ra_scratch(as, rset_exclude(RSET_FPR, tmp));
+        x86Op sub_op;
+        void *krange;
+        if (st == IRT_NUM) {
+          sub_op = XO_SUBSD;
+          krange = &as->J->k64[irt_isu64(ir->t) ? LJ_K64_2P64 : LJ_K64_2P32];
+        } else {
+          sub_op = XO_SUBSS;
+          krange = &as->J->k32[irt_isu64(ir->t) ? LJ_K32_2P64 : LJ_K32_2P32];
+        }
+        emit_rr(as, XO_CMOV + (CC_O<<24), dest|r64, dest2|r64);
+        emit_i8(as, 1);
+        emit_rr(as, XO_ARITHi8, XOg_CMP|r64, dest);
+        emit_rr(as, op, dest2|r64, tmp2);
+        emit_rma(as, sub_op, tmp2, krange);
+        emit_rr(as, XO_MOVAPS, tmp2, tmp);
       }
+      emit_rr(as, op, dest|r64, tmp);
+      ra_left(as, tmp, lref);
     }
   } else if (st >= IRT_I8 && st <= IRT_U16) {  /* Extend to 32 bit integer. */
     Reg left, dest = ra_dest(as, ir, RSET_GPR);

--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -332,14 +332,10 @@ enum {
 
 enum {
 #if LJ_TARGET_X86ORX64
+  LJ_K64_2P32,		/* 2^32 */
   LJ_K64_TOBIT,		/* 2^52 + 2^51 */
   LJ_K64_2P64,		/* 2^64 */
   LJ_K64_M2P64,		/* -2^64 */
-#if LJ_32
-  LJ_K64_M2P64_31,	/* -2^64 or -2^31 */
-#else
-  LJ_K64_M2P64_31 = LJ_K64_M2P64,
-#endif
 #endif
 #if LJ_TARGET_MIPS
   LJ_K64_2P31,		/* 2^31 */
@@ -353,7 +349,8 @@ enum {
 
 enum {
 #if LJ_TARGET_X86ORX64
-  LJ_K32_M2P64_31,	/* -2^64 or -2^31 */
+  LJ_K32_2P32,		/* 2^32 */
+  LJ_K32_2P64,		/* 2^64 */
 #endif
 #if LJ_TARGET_PPC
   LJ_K32_2P52_2P31,	/* 2^52 + 2^31 */

--- a/src/lj_target_x86.h
+++ b/src/lj_target_x86.h
@@ -305,6 +305,7 @@ typedef enum {
   XO_CVTSS2SD =	XO_f30f(5a),
   XO_CVTSD2SS =	XO_f20f(5a),
   XO_ADDSS =	XO_f30f(58),
+  XO_SUBSS =	XO_f30f(5c),
   XO_MOVD =	XO_660f(6e),
   XO_MOVDto =	XO_660f(7e),
 

--- a/src/lj_trace.c
+++ b/src/lj_trace.c
@@ -318,12 +318,11 @@ void lj_trace_initstate(global_State *g)
 
   /* Initialize 32/64 bit constants. */
 #if LJ_TARGET_X86ORX64
+  J->k64[LJ_K64_2P32].u64 = U64x(41f00000,00000000);
   J->k64[LJ_K64_TOBIT].u64 = U64x(43380000,00000000);
-#if LJ_32
-  J->k64[LJ_K64_M2P64_31].u64 = U64x(c1e00000,00000000);
-#endif
   J->k64[LJ_K64_2P64].u64 = U64x(43f00000,00000000);
-  J->k32[LJ_K32_M2P64_31] = LJ_64 ? 0xdf800000 : 0xcf000000;
+  J->k32[LJ_K32_2P64] = 0x5f800000;
+  J->k32[LJ_K32_2P32] = 0x4f800000;
 #endif
 #if LJ_TARGET_X86ORX64 || LJ_TARGET_MIPS64
   J->k64[LJ_K64_M2P64].u64 = U64x(c3f00000,00000000);


### PR DESCRIPTION
This patch fixes a problem where the JITted code for float-to-unsigned-int conversions was not matching the behavior of the interpreted code.

The basic problem is that the domain of `cvttsd2si` doesn't match the domain of `uint64_t` or `uint32_t`.

The previous code would assume a negative result indicated an error and would retry with the input minus 2^64.  However this isn't what we should do for an input of -1, for example; although `uint64 u = -1.0` is undefined, strictly speaking, as it's an out-of-range conversion, common LuaJIT and C practice means we should accept the result to be `0xffffffffffffffff`.  The interpreter inherits this behavior from the C compiler.

This patch changes the JIT to match the interpreter.  In the future we should consider making the interpreter's result more explicit, e.g. by changing the implementation of `lj_num2u64` to be

```c
uint64_t
lj_num2u64 (double n)
{
  if (n < -2^63) then return INT_MIN;
  if (n < 2^63) then return n;
  if (n < 2^64) then return n - 2^64;
  return INT_MIN;
}
```

Thanks to Peter Cawley (@corsix) for advice, help on the test case, an initial patch, and suggested assembly, which looks like:

```asm
2a50ffb3  cvttsd2si rbx, xmm7
2a50ffb8  movaps xmm6, xmm7
2a50ffbb  subsd xmm6, [0x41c52680] ;; 2^64
2a50ffc4  cvttsd2si rdi, xmm6
2a50ffc9  cmp rbx, +0x01
2a50ffcd  cmovo rbx, rdi
```

Corresponding changes were made to the conversion from 32-bit floats and conversion to 32-bit unsigned integers.

See https://github.com/justincormack/ljsyscall/issues/223 for the original discussion.