### PR TITLE
Clarify behavior that if the first argument of jit.off is nil

### DIFF
--- a/doc/ext_jit.html
+++ b/doc/ext_jit.html
@@ -114,6 +114,10 @@ Typical usage is <tt>jit.off(true, true)</tt> in the main chunk
 of a module to turn off JIT compilation for the whole module for
 debugging purposes.
 </p>
+<p>
+If the first argument of <tt>jit.off</tt> is <tt>nil</tt>, disable
+JIT compilation for all modules.
+</p>
 
 <h3 id="jit_flush_tr"><tt>jit.flush(tr)</tt></h3>
 <p>


### PR DESCRIPTION
I think that it is kind that the document has written the behavior when jit.off's first argument is nil.
So, I added that behavior in this pull request.