### PR TITLE
add lua_newcdata() and lua_pushcdataptr() functions to the C API

### DIFF
--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -752,6 +752,26 @@ LUA_API void *lua_newuserdata(lua_State *L, size_t size)
   return uddata(ud);
 }
 
+#if LJ_HASFFI
+#include "lj_cdata.h"
+
+LUA_API void *lua_newcdata(lua_State *L, int id, size_t size)
+{
+  CTState *cts = ctype_cts(L);
+  GCcdata *cd = lj_cdata_new(cts, id, size);
+  setcdataV(L, L->top, cd);
+  incr_top(L);
+  lj_gc_check(L);
+  return cdataptr(cd);
+}
+
+LUA_API void lua_pushcdataptr(lua_State *L, const void *ptr)
+{
+  const void **cd = lua_newcdata(L, CTID_P_CVOID, sizeof(ptr));
+  *cd = ptr;
+}
+#endif
+
 LUA_API void lua_concat(lua_State *L, int n)
 {
   api_checknelems(L, n);

--- a/src/lua.h
+++ b/src/lua.h
@@ -184,6 +184,9 @@ LUA_API void *(lua_newuserdata) (lua_State *L, size_t sz);
 LUA_API int   (lua_getmetatable) (lua_State *L, int objindex);
 LUA_API void  (lua_getfenv) (lua_State *L, int idx);
 
+LUA_API void *lua_newcdata (lua_State *L, int ctid, size_t size);
+LUA_API void  lua_pushcdataptr (lua_State *L, const void *ptr);
+
 
 /*
 ** set functions (stack -> Lua)

--- a/src/lua.h
+++ b/src/lua.h
@@ -184,9 +184,9 @@ LUA_API void *(lua_newuserdata) (lua_State *L, size_t sz);
 LUA_API int   (lua_getmetatable) (lua_State *L, int objindex);
 LUA_API void  (lua_getfenv) (lua_State *L, int idx);
 
-LUA_API void *lua_newcdata (lua_State *L, int ctid, size_t size);
+LUA_API void *lua_newcdata(lua_State* L, int ctid, size_t size);
 LUA_API void  lua_pushcdataptr (lua_State *L, const void *ptr);
-
+LUA_API int lua_getctid(lua_State *L, int narg);
 
 /*
 ** set functions (stack -> Lua)


### PR DESCRIPTION
Given the existence of architectures with 48 bit pointers now (ARM64, PowerPC) and 52 bits on the horizon, the 47-bit limitation of lightuserdata values becomes a liability.
This patch adds the capability to create FFI data objects from the C API in a similar way to full userdata objects, and adds the special case of storing a `const void *` value.
The converse functionality is already provided by the `lua_topointer()` function, which returns a pointer to the content when called on a cdata object.