### PR TITLE
Makefile: only set HOST_RM if not already set

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -191,7 +191,9 @@ CCOPTIONS= $(CCDEBUG) $(ASOPTIONS)
 LDOPTIONS= $(CCDEBUG) $(LDFLAGS)
 
 HOST_CC= $(CC)
+ifndef HOST_RM
 HOST_RM= rm -f
+endif
 # If left blank, minilua is built and used. You can supply an installed
 # copy of (plain) Lua 5.1 or 5.2, plus Lua BitOp. E.g. with: HOST_LUA=lua
 HOST_LUA=


### PR DESCRIPTION
When using Makefile with mingw without msys this line
https://github.com/LuaJIT/LuaJIT/blob/v2.1/src/Makefile#L161
sets the correct delete

but it is overwritten in
https://github.com/LuaJIT/LuaJIT/blob/v2.1/src/Makefile#L194

this PR fixes the issue

I dont know if PR should go to master or 2.0 also