### PR TITLE
Fixed bounds sanitaze errors detected by gcc7

### DIFF
--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -73,7 +73,7 @@ struct dasm_State {
   size_t codesize;		/* Total size of all code sections. */
   int maxsection;		/* 0 <= sectionidx < maxsection. */
   int status;			/* Status code. */
-  dasm_Section sections[1];	/* All sections. Alloc-extended. */
+  dasm_Section sections[DASM_MAXSECPOS];	/* All sections. Alloc-extended. */
 };
 
 /* The size of the core structure depends on the max. number of sections. */

--- a/src/host/buildvm.c
+++ b/src/host/buildvm.c
@@ -96,7 +96,7 @@ static void emit_raw(BuildCtx *ctx)
 static const char *sym_decorate(BuildCtx *ctx,
 				const char *prefix, const char *suffix)
 {
-  char name[256];
+  static char name[2048];
   char *p;
 #if LJ_64
   const char *symprefix = ctx->mode == BUILD_machasm ? "_" : "";
@@ -124,7 +124,7 @@ static const char *sym_decorate(BuildCtx *ctx,
   return p;
 }
 
-#define NRELOCSYM	(sizeof(extnames)/sizeof(extnames[0])-1)
+#define NRELOCSYM	(sizeof(extnames)/sizeof(extnames[0]))
 
 static int relocmap[NRELOCSYM];
 
@@ -430,7 +430,7 @@ ok:
 
 int main(int argc, char **argv)
 {
-  BuildCtx ctx_;
+  BuildCtx ctx_ = {0};
   BuildCtx *ctx = &ctx_;
   int status, binmode;
 

--- a/src/host/minilua.c
+++ b/src/host/minilua.c
@@ -330,12 +330,12 @@ struct UpVal*next;
 typedef struct CClosure{
 GCObject*next;lu_byte tt;lu_byte marked;lu_byte isC;lu_byte nupvalues;GCObject*gclist;struct Table*env;
 lua_CFunction f;
-TValue upvalue[1];
+TValue upvalue[4];
 }CClosure;
 typedef struct LClosure{
 GCObject*next;lu_byte tt;lu_byte marked;lu_byte isC;lu_byte nupvalues;GCObject*gclist;struct Table*env;
 struct Proto*p;
-UpVal*upvals[1];
+UpVal*upvals[4];
 }LClosure;
 typedef union Closure{
 CClosure c;


### PR DESCRIPTION
I`m check this with OpenXray-1.6. This fixes helped prevent random crushes at startup by fixing bounds sanitize errors detected by gcc7.