### PR TITLE
Change the implementation of luaL_addlstring by a faster one

### DIFF
--- a/src/lib_aux.c
+++ b/src/lib_aux.c
@@ -207,8 +207,17 @@ LUALIB_API char *luaL_prepbuffer(luaL_Buffer *B)
 
 LUALIB_API void luaL_addlstring(luaL_Buffer *B, const char *s, size_t l)
 {
-  while (l--)
-    luaL_addchar(B, *s++);
+  lua_State *L = B->L;
+  if (l <= bufffree(B)) {  /* fit into buffer? */
+    memcpy(B->p, s, l);  /* put it there */
+    B->p += l;
+  }
+  else {
+    emptybuffer(B);
+    lua_pushlstring(L, s, l);
+    B->lvl++;  /* add new value into B stack */
+    adjuststack(B);
+  }
 }
 
 LUALIB_API void luaL_addstring(luaL_Buffer *B, const char *s)


### PR DESCRIPTION
Converting LuaJIT to LjsJIT https://github.com/mingodad/ljsjit and making some tests I found that the api function luaL_addlstring in lua 5.1 and LuaJIT is a lot slower than more recent Lua versions so using the luaL_addvalue as base I reimplemented luaL_addlstring and it's now on par with lua 5.3.5