### PR TITLE
[arm64] Constant rematerialization fix for loads clobbering a constant register

### DIFF
--- a/src/lj_asm_arm64.h
+++ b/src/lj_asm_arm64.h
@@ -305,20 +305,8 @@ static void asm_fusexref(ASMState *as, A64Ins ai, Reg rd, IRRef ref,
 	}
 
 	rn = ra_alloc_rematsafe(as, ref1, rd, allow);
-	IRIns *irr = IR(ir->op2);
-	uint32_t m;
-	if (irr+1 == ir && !ra_used(irr) &&
-	    irr->o == IR_ADD && irref_isk(irr->op2)) {
-	  ofs = sizeof(GCstr) + IR(irr->op2)->i;
-	  if (emit_checkofs(ai, ofs)) {
-	    Reg rm = ra_alloc1(as, irr->op1, rset_exclude(allow, rn));
-	    m = A64F_M(rm) | A64F_EX(A64EX_SXTW);
-	    goto skipopm;
-	  }
-	}
-	m = asm_fuseopm(as, 0, ref2, rset_exclude(allow, rn));
+	uint32_t m = asm_fuseopm(as, 0, ref2, rset_exclude(allow, rn));
 	ofs = sizeof(GCstr);
-      skipopm:
 	emit_lso(as, ai, rd, rd, ofs);
 	emit_dn(as, A64I_ADDx^m, rd, rn);
 	return;

--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -161,7 +161,7 @@ nopair:
 /* Try to find an N-step delta relative to other consts with N < lim. */
 static int emit_kdelta(ASMState *as, Reg rd, uint64_t k, int lim)
 {
-  RegSet work = ~as->freeset & RSET_GPR;
+  RegSet work = ~as->freeset & RSET_GPR & as->rematset;
   if (lim <= 1) return 0;  /* Can't beat that. */
   while (work) {
     Reg r = rset_picktop(work);


### PR DESCRIPTION
During rematerialization, the register allocator is unable to see when the write to a destination register from a register holding a constant overwrites the register and incorrectly uses it for rematerialization, thus causing a crash.

The first patch in this PR creates a new rset that keeps track of such constant regs and adds a new register allocator entry point ra_alloc_rematsafe() that marks the register as unsafe if it holds a constant and is reused for the destination.  The arm64 backend uses this entry point and the new rset (rematset) to make sure that it does not use an unsafe constant register for rematerialization either during an ra_allock or in emit_kdelta.