### PR TITLE
Bump minimum MACOSX_DEPLOYMENT_TARGET to 10.6

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -318,7 +318,7 @@ ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector 
 endif
 ifeq (Darwin,$(TARGET_SYS))
   ifeq (,$(MACOSX_DEPLOYMENT_TARGET))
-    export MACOSX_DEPLOYMENT_TARGET=10.4
+    export MACOSX_DEPLOYMENT_TARGET=10.6
   endif
   TARGET_STRIP+= -x
   TARGET_XSHLDFLAGS= -dynamiclib -single_module -undefined dynamic_lookup -fPIC


### PR DESCRIPTION
The macOS SDK for 10.4 has been deprecated as of 10.14, bump to 10.6 so that LuaJIT continues to build out of the box.

Fixes #484.