### PR TITLE
Have powerpc use fake GOT like MIPS

### DIFF
--- a/src/lj_dispatch.c
+++ b/src/lj_dispatch.c
@@ -45,6 +45,18 @@ static const ASMFunction dispatch_got[] = {
 #undef GOTFUNC
 #endif
 
+#if LJ_TARGET_PPC
+#include <math.h>
+LJ_FUNCA_NORET void LJ_FASTCALL lj_ffh_coroutine_wrap_err(lua_State *L,
+							  lua_State *co);
+
+#define GOTFUNC(name)	(ASMFunction)name,
+static const ASMFunction dispatch_got[] = {
+  GOTDEF(GOTFUNC)
+};
+#undef GOTFUNC
+#endif
+
 /* Initialize instruction dispatch table and hot counters. */
 void lj_dispatch_init(GG_State *GG)
 {
@@ -64,6 +76,9 @@ void lj_dispatch_init(GG_State *GG)
   for (i = 0; i < GG_NUM_ASMFF; i++)
     GG->bcff[i] = BCINS_AD(BC__MAX+i, 0, 0);
 #if LJ_TARGET_MIPS
+  memcpy(GG->got, dispatch_got, LJ_GOT__MAX*4);
+#endif
+#if LJ_TARGET_PPC
   memcpy(GG->got, dispatch_got, LJ_GOT__MAX*4);
 #endif
 }

--- a/src/lj_dispatch.h
+++ b/src/lj_dispatch.h
@@ -47,6 +47,21 @@ GOTDEF(GOTENUM)
 };
 #endif
 
+#if LJ_TARGET_PPC
+/* Need our own global offset table for the dreaded MIPS calling conventions. */
+#define GOTDEF(_) \
+  _(floor) _(ceil) _(trunc) _(log) _(log10) _(exp) _(sin) _(cos) _(tan) \
+  _(asin) _(acos) _(atan) _(sinh) _(cosh) _(tanh) _(frexp) _(modf) _(atan2) \
+  _(pow) _(fmod) _(ldexp) _(sqrt)
+
+enum {
+#define GOTENUM(name) LJ_GOT_##name,
+GOTDEF(GOTENUM)
+#undef GOTENUM
+  LJ_GOT__MAX
+};
+#endif
+
 /* Type of hot counter. Must match the code in the assembler VM. */
 /* 16 bits are sufficient. Only 0.0015% overhead with maximum slot penalty. */
 typedef uint16_t HotCount;
@@ -70,7 +85,7 @@ typedef uint16_t HotCount;
 typedef struct GG_State {
   lua_State L;				/* Main thread. */
   global_State g;			/* Global state. */
-#if LJ_TARGET_MIPS
+#if LJ_TARGET_MIPS || LJ_TARGET_PPC
   ASMFunction got[LJ_GOT__MAX];		/* Global offset table. */
 #endif
 #if LJ_HASJIT

--- a/src/vm_ppc.dasc
+++ b/src/vm_ppc.dasc
@@ -59,7 +59,12 @@
 |.define ENV_OFS,	8
 |.endif
 |.else  // No TOC.
-|.macro blex, target; bl extern target@plt; .endmacro
+|.macro blex, target
+|  lwz TMP0, DISPATCH_GOT(target)(DISPATCH)
+|  mtctr TMP0
+|  bctrl
+|  //bl extern target@plt
+|.endmacro
 |.macro .toc, a, b; .endmacro
 |.endif
 |.macro .tocenv, a, b; .if TOCENV; a, b; .endif; .endmacro
@@ -454,6 +459,8 @@
 |// Assumes DISPATCH is relative to GL.
 #define DISPATCH_GL(field)	(GG_DISP2G + (int)offsetof(global_State, field))
 #define DISPATCH_J(field)	(GG_DISP2J + (int)offsetof(jit_State, field))
+#define GG_DISP2GOT		(GG_OFS(got) - GG_OFS(dispatch))
+#define DISPATCH_GOT(name)	(GG_DISP2GOT + 4*LJ_GOT_##name)
 |
 #define PC2PROTO(field)  ((int)offsetof(GCproto, field)-(int)sizeof(GCproto))
 |


### PR DESCRIPTION
Hi, this addresses #481 by having the PowerPC target use a fate GOT like the MIPS target. Since we're still using the 2.0.5 release I made the fix against 2.0 but I could do some investigation to make it applicable to 2.1 too (notably adding any extra functions like `__ledf2` and so on to the GOT as well, if they need to be there.)

I am not sure what the proper way to handle a contribution or PR is so please let me know if there is a process I need to follow, thanks!

