### PR TITLE
Attempt to fix erratic profiler behaviour when called during GC

### DIFF
--- a/src/lj_gc.c
+++ b/src/lj_gc.c
@@ -466,6 +466,7 @@ static void gc_call_finalizer(global_State *g, lua_State *L,
   TValue *top;
   lj_trace_abort(g);
   hook_entergc(g);  /* Disable hooks and new traces during __gc. */
+  lj_dispatch_update(g);
   g->gc.threshold = LJ_MAX_MEM;  /* Prevent GC steps. */
   top = L->top;
   copyTV(L, top++, mo);
@@ -474,6 +475,7 @@ static void gc_call_finalizer(global_State *g, lua_State *L,
   L->top = top+1;
   errcode = lj_vm_pcall(L, top, 1+0, -1);  /* Stack: |mo|o| -> | */
   hook_restore(g, oldh);
+  lj_dispatch_update(g);
   g->gc.threshold = oldt;  /* Restore GC threshold. */
   if (errcode)
     lj_err_throw(L, errcode);  /* Propagate errors. */

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -638,7 +638,7 @@ typedef struct global_State {
 #define HOOK_PROFILE		0x80
 #define hook_active(g)		((g)->hookmask & HOOK_ACTIVE)
 #define hook_enter(g)		((g)->hookmask |= HOOK_ACTIVE)
-#define hook_entergc(g)		((g)->hookmask |= (HOOK_ACTIVE|HOOK_GC))
+#define hook_entergc(g)		((g)->hookmask = ((g)->hookmask | (HOOK_ACTIVE|HOOK_GC)) & ~HOOK_PROFILE)
 #define hook_vmevent(g)		((g)->hookmask |= (HOOK_ACTIVE|HOOK_VMEVENT))
 #define hook_leave(g)		((g)->hookmask &= ~HOOK_ACTIVE)
 #define hook_save(g)		((g)->hookmask & ~HOOK_EVENTMASK)

--- a/src/lj_profile.c
+++ b/src/lj_profile.c
@@ -153,7 +153,7 @@ static void profile_trigger(ProfileState *ps)
   profile_lock(ps);
   ps->samples++;  /* Always increment number of samples. */
   mask = g->hookmask;
-  if (!(mask & (HOOK_PROFILE|HOOK_VMEVENT))) {  /* Set profile hook. */
+  if (!(mask & (HOOK_PROFILE|HOOK_VMEVENT|HOOK_GC))) {  /* Set profile hook. */
     int st = g->vmstate;
     ps->vmstate = st >= 0 ? 'N' :
 		  st == ~LJ_VMST_INTERP ? 'I' :


### PR DESCRIPTION
It turns out that calling the hook profiler while a Lua finalizer is
running causes some issues with VM internal hook flags and dispatch
table. Hooks are restored but not dispatch table, which causes both to
be out-of-sync. This patch ensures that the dispatch table stays in sync
and that we will not call the profiling hook when a finalizer is
running.

The extra dispatch table updates are nearly no-ops most of the time. as
the flags would not match only when the `HOOK_PROFILE` is set (which
should be quite unusual). Experiments at 100Hz with a extremely GC
intensive script showed an overhead of about 1%. The actual effect on a
production workload should be lower.

fixes LuaJIT/LuaJIT#512