### PR TITLE
Prevent crash during ffi.load() when dlerror() returns NULL

### DIFF
--- a/src/lj_clib.c
+++ b/src/lj_clib.c
@@ -119,6 +119,9 @@ static void *clib_loadlib(lua_State *L, const char *name, int global)
 		   RTLD_LAZY | (global?RTLD_GLOBAL:RTLD_LOCAL));
   if (!h) {
     const char *e, *err = dlerror();
+    /* Per the standard definition of `dlerror`, this should always be safe, but we have
+     * observed `dlerror()` returning NULL on Android 7.1.1 SDK 25 (Oculus Quest) anyway,
+     * which causes a crash. */
     if (err && *err == '/' && (e = strchr(err, ':')) &&
 	(name = clib_resolve_lds(L, strdata(lj_str_new(L, err, e-err))))) {
       h = dlopen(name, RTLD_LAZY | (global?RTLD_GLOBAL:RTLD_LOCAL));

--- a/src/lj_clib.c
+++ b/src/lj_clib.c
@@ -119,12 +119,14 @@ static void *clib_loadlib(lua_State *L, const char *name, int global)
 		   RTLD_LAZY | (global?RTLD_GLOBAL:RTLD_LOCAL));
   if (!h) {
     const char *e, *err = dlerror();
-    if (*err == '/' && (e = strchr(err, ':')) &&
+    if (err && *err == '/' && (e = strchr(err, ':')) &&
 	(name = clib_resolve_lds(L, strdata(lj_str_new(L, err, e-err))))) {
       h = dlopen(name, RTLD_LAZY | (global?RTLD_GLOBAL:RTLD_LOCAL));
       if (h) return h;
       err = dlerror();
     }
+    if (!err) /* Tolerate nonstandard dlerror implementations */
+      err = "Unknown dlopen error";
     lj_err_callermsg(L, err);
   }
   return h;


### PR DESCRIPTION
The ffi.load() implementation assumes the string returned from dlerror() is non-NULL and immediately dereferences it. Per the standard definition of dlerror, this should always be safe, but we have observed dlerror() returning NULL on Android (Oculus Quest) anyway, which causes a crash. Patch issues a well-formed error instead of crashing.