### PR TITLE
debug.getinfo arbitrary memory read/write

### DIFF
--- a/src/lj_debug.c
+++ b/src/lj_debug.c
@@ -429,7 +429,8 @@ int lj_debug_getinfo(lua_State *L, const char *what, lj_Debug *ar, int ext)
   GCfunc *fn;
   if (*what == '>') {
     TValue *func = L->top - 1;
-    api_check(L, tvisfunc(func));
+    if (!tvisfunc(func))
+	  return 0;
     fn = funcV(func);
     L->top--;
     what++;


### PR DESCRIPTION
If the first argument is a valid stack level and the first character in the options argument for debug.getinfo is `>`, then the final argument will be used as the function.
e.g.
`debug.getinfo(0, ">", debug.getinfo)`

In release mode, the final argument's type is never ensured to be a function. This means that we can pass whatever we want to it. For example, if we passed the double representation of a uintptr_t that points to whichever address we want to read memory from it'll return a function at that address. To read memory, we can simply call `debug.getfenv` on the function and then call `string.format("%p",env)` to get the contents of the memory. This is shown in a POC below:

```lua
-- Getting the length of a string

local str = "abcd"

-- 12 is the offset of string length
local address = tonumber( string.format( "%p", str ), 16 ) + 12

-- Convert to a double, address - 8 (env offset)
-- https://github.com/notcake/carrier/blob/master/lua/carrier/packages/pylon.bitconverter.lua#L219-L244
address = UInt32sToDouble( address - 8, 0 )

-- This turns the address into a function
local func = debug.getinfo( 0, ">f", address ).func

-- This is supposed to get the environment of the function
-- but it allows us to read memory by formatting the address
-- into a pointer
local length = debug.getfenv( func )

-- Format the address into a pointer
-- prints 4, the length of the string
print( tonumber( string.format( "%p", length ), 16 ) ) 
```

This can be further exploited to enable arbitrary memory writing.