### PR TITLE
Add missing Make dependencies

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -637,7 +637,7 @@ $(MINILUA_T): $(MINILUA_O)
 	$(E) "HOSTLINK  $@"
 	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
 
-host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua
+host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua lj_arch.h lua.h luaconf.h
 	$(E) "DYNASM    $@"
 	$(Q)$(DASM) $(DASM_FLAGS) -o $@ $(DASM_DASC)
 


### PR DESCRIPTION
Hello

this commit fixes a fault in the `src/Makefile`. Specifically, `lj_arch.h lua.h luaconf.h` are missing from the rule in line 640. The build can cause incorrect results when the project is incrementally built. For example, any changes in `lj_arch.h lua.h luaconf.h` will not cause the file `host/buildvm_arch.h` to be rebuilt.