### PR TITLE
Fix typo in bcsave.lua

### DIFF
--- a/src/jit/bcsave.lua
+++ b/src/jit/bcsave.lua
@@ -133,7 +133,7 @@ local function bcsave_c(ctx, output, s)
   local fp = savefile(output, "w")
   if ctx.type == "c" then
     fp:write(format([[
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C"
 #endif
 #ifdef _WIN32


### PR DESCRIPTION
The correct macro to identify a C++ compiler is `__cplusplus`, with two underscores.