### PR TITLE
Fix conversion for strings with null char

### DIFF
--- a/src/lj_cparse.c
+++ b/src/lj_cparse.c
@@ -164,7 +164,8 @@ static CPToken cp_number(CPState *cp)
   TValue o;
   do { cp_save(cp, cp->c); } while (lj_char_isident(cp_get(cp)));
   cp_save(cp, '\0');
-  fmt = lj_strscan_scan((const uint8_t *)cp->sb.buf, &o, STRSCAN_OPT_C);
+  fmt = lj_strscan_scan((const uint8_t *)cp->sb.buf, cp->sb.n - 1, &o,
+			STRSCAN_OPT_C);
   if (fmt == STRSCAN_INT) cp->val.id = CTID_INT32;
   else if (fmt == STRSCAN_U32) cp->val.id = CTID_UINT32;
   else if (!(cp->mode & CPARSE_MODE_SKIP))

--- a/src/lj_lex.c
+++ b/src/lj_lex.c
@@ -105,7 +105,7 @@ static void lex_number(LexState *ls, TValue *tv)
     save_and_next(ls);
   }
   save(ls, '\0');
-  fmt = lj_strscan_scan((const uint8_t *)ls->sb.buf, tv,
+  fmt = lj_strscan_scan((const uint8_t *)ls->sb.buf, ls->sb.n - 1, tv,
 	  (LJ_DUALNUM ? STRSCAN_OPT_TOINT : STRSCAN_OPT_TONUM) |
 	  (LJ_HASFFI ? (STRSCAN_OPT_LL|STRSCAN_OPT_IMAG) : 0));
   if (LJ_DUALNUM && fmt == STRSCAN_INT) {

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -327,9 +327,10 @@ static StrScanFmt strscan_dec(const uint8_t *p, TValue *o,
 }
 
 /* Scan string containing a number. Returns format. Returns value in o. */
-StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt)
+StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o, uint32_t opt)
 {
   int32_t neg = 0;
+  const uint8_t *pe = p + len;
 
   /* Remove leading space, parse sign and non-numbers. */
   if (LJ_UNLIKELY(!lj_char_isdigit(*p))) {
@@ -347,7 +348,7 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt)
 	p += 3;
       }
       while (lj_char_isspace(*p)) p++;
-      if (*p) return STRSCAN_ERROR;
+      if (*p || p < pe) return STRSCAN_ERROR;
       o->u64 = tmp.u64;
       return STRSCAN_NUM;
     }
@@ -442,6 +443,8 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt)
       if (*p) return STRSCAN_ERROR;
     }
 
+    if (p < pe) return STRSCAN_ERROR;
+
     /* Fast path for decimal 32 bit integers. */
     if (fmt == STRSCAN_INT && base == 10 &&
 	(dig < 10 || (dig == 10 && *sp <= '2' && x < 0x80000000u+neg))) {
@@ -474,7 +477,7 @@ StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt)
 
 int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o)
 {
-  StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), o,
+  StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), str->len, o,
 				   STRSCAN_OPT_TONUM);
   lua_assert(fmt == STRSCAN_ERROR || fmt == STRSCAN_NUM);
   return (fmt != STRSCAN_ERROR);
@@ -483,7 +486,7 @@ int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o)
 #if LJ_DUALNUM
 int LJ_FASTCALL lj_strscan_number(GCstr *str, TValue *o)
 {
-  StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), o,
+  StrScanFmt fmt = lj_strscan_scan((const uint8_t *)strdata(str), str->len, o,
 				   STRSCAN_OPT_TOINT);
   lua_assert(fmt == STRSCAN_ERROR || fmt == STRSCAN_NUM || fmt == STRSCAN_INT);
   if (fmt == STRSCAN_INT) setitype(o, LJ_TISNUM);

--- a/src/lj_strscan.h
+++ b/src/lj_strscan.h
@@ -22,7 +22,8 @@ typedef enum {
   STRSCAN_INT, STRSCAN_U32, STRSCAN_I64, STRSCAN_U64,
 } StrScanFmt;
 
-LJ_FUNC StrScanFmt lj_strscan_scan(const uint8_t *p, TValue *o, uint32_t opt);
+LJ_FUNC StrScanFmt lj_strscan_scan(const uint8_t *p, MSize len, TValue *o,
+				   uint32_t opt);
 LJ_FUNC int LJ_FASTCALL lj_strscan_num(GCstr *str, TValue *o);
 #if LJ_DUALNUM
 LJ_FUNC int LJ_FASTCALL lj_strscan_number(GCstr *str, TValue *o);


### PR DESCRIPTION
We recently faced [the issue](https://github.com/tarantool/tarantool/issues/4773) in our platform and as a result of investigation we found its root cause.

---

The routine used for conversion a string representation to number
(lj_strscan_scan) doesn't respect the size of the given string/buffer.
Such behaviour leads to the following results:

| local a = tonumber("inf\x00imun")   -- the result is 'inf'
| local b = tonumber("\x36\x00\x80") -- the result is 6

The behaviour described above is similar to the one vanila Lua 5.1 has:

| $ ./lua -e 'print(_VERSION, tonumber("inf"..string.char(0).."imun"))'
| Lua 5.1	inf

However, the issue is fixed in Lua 5.2 and the results are the following:
| $ ./lua -e 'print(_VERSION, tonumber("inf"..string.char(0).."imun"))'
| Lua 5.2	nil

The patch introduces additional parameter to lj_strscan_scan routine to
detect whether there is nothing left after the null character.

Signed-off-by: Igor Munkin <imun@cpan.org>

---

@MikePall, I have no particular resolution since it looks like a bug, but still complies Lua 5.1 behaviour. It isn't mentioned within Lua Reference Manual so gets into a gray zone. If you consider the patch not as bugfix but as the one breaking the compatibility, feel free to discard it.