### PR TITLE
Fix building with ToT clang

### DIFF
--- a/src/vm_x86.dasc
+++ b/src/vm_x86.dasc
@@ -6182,7 +6182,7 @@ static void emit_asm_debug(BuildCtx *ctx)
     fprintf(ctx->fp, "\t.section .eh_frame,\"aw\",@progbits\n");
 #endif
 #else
-    fprintf(ctx->fp, "\t.section .eh_frame,\"a\",@progbits\n");
+    fprintf(ctx->fp, "\t.section .eh_frame,\"a\",@unwind\n");
 #endif
     fprintf(ctx->fp,
 	".Lframe1:\n"


### PR DESCRIPTION
ToT clang complains that ".eh_frame" section has @progbits
section type. Fix this by changing it to "@unwind".

GNU assembler 2.35+ will also error out on this input.
https://sourceware.org/ml/binutils/2020-02/msg00129.html