### PR TITLE
 -jv now prints Instruction name and IR name instead of ID

### DIFF
--- a/src/host/buildvm.c
+++ b/src/host/buildvm.c
@@ -291,6 +291,12 @@ static const char *const trace_errors[] = {
   NULL
 };
 
+static const char *const trace_errors_names[] = {
+#define TREDEF(name, msg)	#name,
+#include "lj_traceerr.h"
+  NULL
+};
+
 static const char *lower(char *buf, const char *s)
 {
   char *p = buf;
@@ -354,7 +360,11 @@ static void emit_vmdef(BuildCtx *ctx)
   fprintf(ctx->fp, "traceerr = {\n[0]=");
   for (i = 0; trace_errors[i]; i++)
     fprintf(ctx->fp, "\"%s\",\n", trace_errors[i]);
+  for (i = 0; trace_errors[i]; i++)
+    fprintf(ctx->fp, "%s = \"%s\",\n", trace_errors_names[i], trace_errors[i]);
   fprintf(ctx->fp, "},\n\n");
+
+
 }
 
 /* -- Argument parsing ---------------------------------------------------- */

--- a/src/jit/v.lua
+++ b/src/jit/v.lua
@@ -86,15 +86,13 @@ local function fmtfunc(func, pc)
   end
 end
 
+local vmdef_name_table = {
+  [vmdef.traceerr.NYIBC] = "bcnames",
+  [vmdef.traceerr.NYIIR] = "irnames"
+}
+
 local function vmdef_name(id, message)
-  local targetTable;
-  if string.find(message, "bytecode %s", 1, true) then
-  	targetTable = "bcnames"
-  elseif string.find(message, "IR instruction %s", 1, true) then
-  	targetTable = "irnames"
-  else
-  	error("Unimplemented error message : " .. message)
-  end
+  local targetTable = assert(vmdef_name_table[message], "Error message not implemented : " .. message)
 
   -- 6 comes from "%-6s" in buildvm.c
   return vmdef[targetTable]:sub(id * 6 + 1, id * 6 + 7):gsub("%s", "")

--- a/src/jit/v.lua
+++ b/src/jit/v.lua
@@ -91,9 +91,7 @@ local vmdef_name_table = {
   [vmdef.traceerr.NYIIR] = "irnames"
 }
 
-local function vmdef_name(id, message)
-  local targetTable = assert(vmdef_name_table[message], "Error message not implemented : " .. message)
-
+local function vmdef_name(id, targetTable)
   -- 6 comes from "%-6s" in buildvm.c
   return vmdef[targetTable]:sub(id * 6 + 1, id * 6 + 7):gsub("%s", "")
 end
@@ -104,9 +102,13 @@ local function fmterr(err, info)
   	local errmsg = vmdef.traceerr[err]
     if type(info) == "function" then
     	info = fmtfunc(info)
-    elseif errmsg:find("%s", 1, true) then
-    	info = vmdef_name(info, errmsg) end
-    err = format(vmdef.traceerr[err], info)
+    else
+    	local targetTable = vmdef_name_table[errmsg]
+    	if targetTable then
+    		info = vmdef_name(info, targetTable)
+    	end
+    end
+    err = format(errmsg, info)
   end
   return err
 end

--- a/src/jit/v.lua
+++ b/src/jit/v.lua
@@ -86,10 +86,28 @@ local function fmtfunc(func, pc)
   end
 end
 
+local function vmdef_name(id, message)
+  local targetTable;
+  if string.find(message, "bytecode %s", 1, true) then
+  	targetTable = "bcnames"
+  elseif string.find(message, "IR instruction %s", 1, true) then
+  	targetTable = "irnames"
+  else
+  	error("Unimplemented error message : " .. message)
+  end
+
+  -- 6 comes from "%-6s" in buildvm.c
+  return vmdef[targetTable]:sub(id * 6 + 1, id * 6 + 7):gsub("%s", "")
+end
+
 -- Format trace error message.
 local function fmterr(err, info)
   if type(err) == "number" then
-    if type(info) == "function" then info = fmtfunc(info) end
+  	local errmsg = vmdef.traceerr[err]
+    if type(info) == "function" then
+    	info = fmtfunc(info)
+    elseif errmsg:find("%s", 1, true) then
+    	info = vmdef_name(info, errmsg) end
     err = format(vmdef.traceerr[err], info)
   end
   return err

--- a/src/jit/v.lua
+++ b/src/jit/v.lua
@@ -93,7 +93,7 @@ local vmdef_name_table = {
 
 local function vmdef_name(id, targetTable)
   -- 6 comes from "%-6s" in buildvm.c
-  return vmdef[targetTable]:sub(id * 6 + 1, id * 6 + 7):gsub("%s", "")
+  return vmdef[targetTable]:sub(id * 6 + 1, id * 6 + 6):gsub("%s", "")
 end
 
 -- Format trace error message.

--- a/src/lj_traceerr.h
+++ b/src/lj_traceerr.h
@@ -13,7 +13,7 @@ TREDEF(STACKOV,	"trace too deep")
 TREDEF(SNAPOV,	"too many snapshots")
 TREDEF(BLACKL,	"blacklisted")
 TREDEF(RETRY,	"retry recording")
-TREDEF(NYIBC,	"NYI: bytecode %d")
+TREDEF(NYIBC,	"NYI: bytecode %s")
 
 /* Recording loop ops. */
 TREDEF(LLEAVE,	"leaving loop in root trace")
@@ -50,7 +50,7 @@ TREDEF(MCODEOV,	"machine code too long")
 TREDEF(MCODELM,	"hit mcode limit (retrying)")
 TREDEF(SPILLOV,	"too many spill slots")
 TREDEF(BADRA,	"inconsistent register allocation")
-TREDEF(NYIIR,	"NYI: cannot assemble IR instruction %d")
+TREDEF(NYIIR,	"NYI: cannot assemble IR instruction %s")
 TREDEF(NYIPHI,	"NYI: PHI shuffling too complex")
 TREDEF(NYICOAL,	"NYI: register coalescing too complex")
 


### PR DESCRIPTION
when using `luajit -jv`


from :  
```txt
[TRACE --- test.lua:7 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode 51 at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode 51 at test.lua:2]
```
to

```txt
[TRACE --- test.lua:7 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:7 -- NYI: bytecode FNEWT at test.lua:2]
[TRACE --- test.lua:1 -- NYI: bytecode FNEWT at test.lua:2]
```

It also adds support for IR instruction, didn't manage to test it but there is no reason it doesn't work.