### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -312,7 +312,7 @@ cd vcpkg
 <p>
 The luajit port in vcpkg is kept up to date by microsoft team members and community contributors.
 If the version is out of date, please create an issue or pull request on the vcpkg repository.
-</P>
+</p>
 <h2 id="cross">Cross-compiling LuaJIT</h2>
 <p>
 First, let's clear up some terminology:

--- a/doc/install.html
+++ b/doc/install.html
@@ -298,7 +298,21 @@ absolute path names &mdash; all modules are loaded relative to the
 directory where <tt>luajit.exe</tt> is installed
 (see <tt>src/luaconf.h</tt>).
 </p>
-
+<h3>Building and installing with vcpkg</h3>
+<p>
+Alternatively, you can build and install LuaJIT using vcpkg dependency manager:
+</p>
+<pre class="code">
+git clone https://github.com/Microsoft/vcpkg.git
+cd vcpkg
+./bootstrap-vcpkg.bat
+./vcpkg integrate install
+./vcpkg install luajit
+</pre>
+<p>
+The luajit port in vcpkg is kept up to date by microsoft team members and community contributors.
+If the version is out of date, please create an issue or pull request on the vcpkg repository.
+</P>
 <h2 id="cross">Cross-compiling LuaJIT</h2>
 <p>
 First, let's clear up some terminology:


### PR DESCRIPTION
LuaJIT is available as a port in VCPKG , documenting the install process here will help users get started by providing a single set of commands to build LuaJIT, ready to be included in their projects.

VCPKG is a C++ library manager that simplifies installation for LuaJIT and other project dependencies, we also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.
