### PR TITLE
Fix an unpack bug

### DIFF
--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -227,7 +227,7 @@ LJLIB_CF(unpack)
 	      lj_lib_checkint(L, 3) : (int32_t)lj_tab_len(t);
   if (i > e) return 0;
   n = (uint32_t)e - (uint32_t)i;  // number of elements minus 1
-  if (n > (INT_MAX - 10) || !lua_checkstack(L, ++n))
+  if (n > (INT32_MAX - 10) || !lua_checkstack(L, ++n))
     lj_err_caller(L, LJ_ERR_UNPACK);
   do {
     cTValue *tv = lj_tab_getint(t, i);

--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -221,12 +221,13 @@ LJLIB_CF(rawlen)		LJLIB_REC(.)
 LJLIB_CF(unpack)
 {
   GCtab *t = lj_lib_checktab(L, 1);
-  int32_t n, i = lj_lib_optint(L, 2, 1);
+  uint32_t n;
+  int32_t i = lj_lib_optint(L, 2, 1);
   int32_t e = (L->base+3-1 < L->top && !tvisnil(L->base+3-1)) ?
 	      lj_lib_checkint(L, 3) : (int32_t)lj_tab_len(t);
   if (i > e) return 0;
-  n = e - i + 1;
-  if (n <= 0 || !lua_checkstack(L, n))
+  n = (uint32_t)e - (uint32_t)i;  // number of elements minus 1
+  if (n > (INT_MAX - 10) || !lua_checkstack(L, ++n))
     lj_err_caller(L, LJ_ERR_UNPACK);
   do {
     cTValue *tv = lj_tab_getint(t, i);


### PR DESCRIPTION
I've applied the patch at https://www.lua.org/bugs.html#5.2.3-1

I did not change minilua.


### How to test

Execute this with luajit and test if it still crashes:
```lua
unpack({}, 0, 2^31 - 1)
```

