### PR TITLE
Support up to 3 non-zero 47-bit segments for lightuserdata.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -277,6 +277,10 @@ endif
 endif
 endif
 
+ifeq (SunOS,$(TARGET_SYS))
+  TARGET_XCFLAGS+= -DLJ_LIGHTUD_SEGMENTS
+endif
+
 ifneq (,$(findstring LJ_TARGET_PS3 1,$(TARGET_TESTARCH)))
   TARGET_SYS= PS3
   TARGET_ARCH+= -D__CELLOS_LV2__

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -49,6 +49,7 @@
 #define LUAJIT_TARGET	LUAJIT_ARCH_ARM
 #elif defined(__aarch64__)
 #define LUAJIT_TARGET	LUAJIT_ARCH_ARM64
+#define LJ_LIGHTUD_SEGMENTS
 #elif defined(__ppc__) || defined(__ppc) || defined(__PPC__) || defined(__PPC) || defined(__powerpc__) || defined(__powerpc) || defined(__POWERPC__) || defined(__POWERPC) || defined(_M_PPC)
 #define LUAJIT_TARGET	LUAJIT_ARCH_PPC
 #elif defined(__mips64__) || defined(__mips64) || defined(__MIPS64__) || defined(__MIPS64)

--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -621,6 +621,7 @@ typedef struct global_State {
   MRef jit_base;	/* Current JIT code L->base or NULL. */
   MRef ctype_state;	/* Pointer to C type state. */
   GCRef gcroot[GCROOT_MAX];  /* GC roots. */
+  uintptr_t lightud_off[3];  /* up to three 47-bit base offsets */
 } global_State;
 
 #define mainthread(g)	(&gcref(g->mainthref)->th)


### PR DESCRIPTION
* Increases the global state size by 3*sizeof(uintptr_t).
* Only changes behavior on LJ_64 builds.
* Enabled via the LJ_LIGHTUD_SEGMENTS define.
* In addition to the 47-bit segment with a base of 0, support
  three additional arbitrary 47-bit segment bases for lightuserdata.
* When active, requires lightuserdata to be 4-byte aligned.
* Enabled for `__aarch64__` and SunOS