### PR TITLE
Must load L in CARG1 to call lj_tab_setinth

### DIFF
--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -710,6 +710,7 @@ static void build_subroutines(BuildCtx *ctx)
   |
   |->vmeta_tsetr:
   |  sxtw CARG3, TMP1w
+  |  mov CARG1, L
   |  str BASE, L->base
   |  str PC, SAVE_PC
   |  bl extern lj_tab_setinth  // (lua_State *L, GCtab *t, int32_t key)


### PR DESCRIPTION
On an ARM64 host, `luajit -e 'table.move({}, 1, 1, 1, {})'` segfaults.

The coredump shows that the `lj_tab_setinth()` function is called with a bogus `L` pointer (CARG1, or register x0) from `vmeta_tsetr`.  This is because BC_TSETR uses CARG1 for the array part pointer (which is NULL in this testcase because the target table is empty).

This patch loads CARG1 with the correct L pointer.  

fixes Kong/kong#5869
