### PR TITLE
Add support for $(pkg-config --cflags --libs --static luajit) with MiNGW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ INSTALL_F= install -m 0644
 UNINSTALL= $(RM)
 LDCONFIG= ldconfig -n 2>/dev/null
 SED_PC= sed -e "s|^prefix=.*|prefix=$(PREFIX)|" \
-            -e "s|^multilib=.*|multilib=$(MULTILIB)|"
+            -e "s|^multilib=.*|multilib=$(MULTILIB)|" \
+            $(SED_PC_OPTIONS_WINDOWS)
 
 FILE_T= luajit
 FILE_A= libluajit.a
@@ -102,6 +103,18 @@ ifeq (Darwin,$(TARGET_SYS))
   INSTALL_SOSHORT1= $(INSTALL_DYLIBSHORT1)
   INSTALL_SOSHORT2= $(INSTALL_DYLIBSHORT2)
   LDCONFIG= :
+endif
+
+ifeq (Windows,$(TARGET_SYS))
+  # "-Wl,-E" and "-ldl" are removed.
+  # Because "-Wl,-E" isn't supported with MinGW and dlopen() isn't used
+  # with MinGW.
+  #
+  # You can't link LuaJIT statically on Windows if you want to load Lua/C
+  # modules at runtime.
+  # See the "Embedding LuaJIT" section at https://luajit.org/install.html .
+  SED_PC_OPTIONS_WINDOWS= -e "s|-Wl,-E||" \
+                          -e "s|-ldl||"
 endif
 
 ##############################################################################


### PR DESCRIPTION
"-Wl,-E" and "-ldl" are removed.

Because "-Wl,-E" isn't supported with MinGW and dlopen() isn't used
with MinGW.

"-Wl,-E" doesn't report error. It just reports the following warning:

    ld.exe: warning: --export-dynamic is not supported for PE+
    targets, did you mean --export-all-symbols?

But this change removes the flag because we don't need to export
symbols on Windows. We can't link LuaJIT statically on Windows if we
want to load Lua/C modules at runtime as mentioned in the "Embedding
LuaJIT" section at https://luajit.org/install.html .

"-ldl" reports error because libdl doesn't exist on Windows. We need
to remove the (needless) flag.