### PR TITLE
x86: Reset KBASEa after chaining new cframe

### DIFF
--- a/src/vm_x86.dasc
+++ b/src/vm_x86.dasc
@@ -719,6 +719,10 @@ static void build_subroutines(BuildCtx *ctx)
   |  sub RD, RA
   |  shr NARGS:RD, 3
   |  add NARGS:RD, 1			// RD = nargs+1
+  |.if X64
+  |  // Reset KBASEa to prevent lower 32 address bits clashing in vmeta_call.
+  |  xor KBASEa, KBASEa
+  |.endif
   |
   |->vm_call_dispatch:
   |  mov LFUNC:RB, [RA-8]


### PR DESCRIPTION
**TL;DR**: There *might* be the address parts clashing when comparing lower bits of 64-bit pointer on host stack (i.e. cframe head) and 32-bit address pointer (i.e Lua stack base) on x86 platform with disabled `LJ_GC64`. I have no reproducer for this failure, so I can't report the bug for others arches. However, I glanced other .dasc files and see no similar hacks.

---

We faced the issue in our platform on production, that occurs periodically. I have been failing to hunt down the bug for more than a year, but we finally got a useful coredump couple days ago. I described a bug finding path below to show the root cause.

At first here is the host backtrace and the guest stack dump for currently executing Lua coroutine (the latter one can be obtained via [this](https://github.com/tarantool/luajit/blob/tarantool/src/luajit-gdb.py) gdb extension).
```
(gdb) bt
#0  0x00007f3c9329f387 in raise () from /tarantool-core/lib64/libc.so.6
#1  0x00007f3c932a0a78 in abort () from /tarantool-core/lib64/libc.so.6
#2  0x000000000054372e in lj_vm_ffi_call () at buildvm_x86.dasc:2590
#3  0x00000000005938e3 in lj_ccall_func (L=L@entry=0x40dbadb0, cd=<optimized out>) at lj_ccall.c:1150
#4  0x00000000005ab2f3 in lj_cf_ffi_meta___call (L=0x40dbadb0) at lib_ffi.c:230
#5  0x0000000000541744 in lj_BC_FUNCC () at buildvm_x86.dasc:809
#6  0x0000000000545ef8 in lj_err_run (L=L@entry=0x40dbadb0) at lj_err.c:620
#7  0x000000000054633f in lj_err_callermsg (L=L@entry=0x40dbadb0, msg=<optimized out>) at lj_err.c:727
#8  0x0000000000546414 in err_argmsg (L=L@entry=0x40dbadb0, narg=narg@entry=1, msg=<optimized out>) at lj_err.c:759
#9  0x0000000000546672 in lj_err_argtype (L=0x40dbadb0, narg=narg@entry=1, xname=<optimized out>) at lj_err.c:799
#10 0x00000000005466d7 in lj_err_argt (L=<optimized out>, narg=narg@entry=1, tt=tt@entry=10) at lj_err.c:805
#11 0x00000000005ab1e6 in ffi_checkcdata (L=L@entry=0x40dbadb0, narg=1) at lib_ffi.c:73
#12 0x00000000005ab211 in lj_cf_ffi_meta___call (L=0x40dbadb0) at lib_ffi.c:221
#13 0x0000000000541744 in lj_BC_FUNCC () at buildvm_x86.dasc:809
#14 0x00000000005439cc in gc_call_finalizer (g=g@entry=0x40a993b8, L=L@entry=0x40dbadb0, o=o@entry=0x40e593e0, mo=<optimized out>) at lj_gc.c:502
#15 0x0000000000543b6e in gc_finalize (L=0x40dbadb0) at lj_gc.c:536
#16 0x0000000000544f0d in gc_onestep (L=L@entry=0x40dbadb0) at lj_gc.c:695
#17 0x0000000000545244 in lj_gc_step (L=0x40dbadb0) at lj_gc.c:725
#18 0x0000000000540a2c in lj_BC_TNEW () at buildvm_x86.dasc:556
#19 0x00000000004e71bd in execute_lua_call (L=0x40dbadb0) at /source/tarantool-1.10.6.44/src/box/lua/call.c:302
#20 0x0000000000541744 in lj_BC_FUNCC () at buildvm_x86.dasc:809
#21 0x00000000005568ba in lua_pcall (L=0x40dbadb0, nargs=<optimized out>, nresults=<optimized out>, errfunc=<optimized out>) at lj_api.c:1158
#22 0x00000000005059d0 in luaT_call (L=0x40dbadb0, nargs=1, nreturns=-1) at /source/tarantool-1.10.6.44/src/lua/utils.c:979
#23 0x00000000004e770a in box_process_lua (request=0x7f3c8a011ab0, base=0x7f324187fe30, handler=0x4e708f <execute_lua_call>) at /source/tarantool-1.10.6.44/src/box/lua/call.c:442
#24 0x00000000004e7750 in box_lua_call (request=0x7f3c8a011ab0, port=0x7f324187fe30) at /source/tarantool-1.10.6.44/src/box/lua/call.c:452
#25 0x00000000004e5050 in box_process_call (request=0x7f3c8a011ab0, port=0x7f324187fe30) at /source/tarantool-1.10.6.44/src/box/call.c:199
#26 0x0000000000416d8c in tx_process_call (m=0x7f3c8a011a40) at /source/tarantool-1.10.6.44/src/box/iproto.cc:1595
#27 0x0000000000520e6a in cmsg_deliver (msg=0x7f3c8a011a40) at /source/tarantool-1.10.6.44/src/cbus.c:375
#28 0x0000000000521e44 in fiber_pool_f (ap=0x7f3244ab08b8) at /source/tarantool-1.10.6.44/src/fiber_pool.c:64
#29 0x0000000000410a8a in fiber_cxx_invoke(fiber_func, typedef __va_list_tag __va_list_tag *) (f=0x521cb1 <fiber_pool_f>, ap=0x7f3244ab08b8) at /source/tarantool-1.10.6.44/src/fiber.h:678
#30 0x000000000051af5e in fiber_loop (data=0x0) at /source/tarantool-1.10.6.44/src/fiber.c:713
#31 0x00000000006abb53 in coro_init () at /source/tarantool-1.10.6.44/third_party/coro/coro.c:110
(gdb) f 3
#3  0x00000000005938e3 in lj_ccall_func (L=L@entry=0x40dbadb0, cd=<optimized out>) at lj_ccall.c:1150
1150        lj_vm_ffi_call(&cc);
(gdb) lj-stack L
0x418800c0:0x418800e0 [    ] 5 slots: Red zone
0x418800b8            [   M]
0x4187fc20:0x418800b0 [    ] 147 slots: Free stack slots
0x4187fc18            [  T ]
0x4187fc10            [ B  ] VALUE: cdata @ 0x40d72e20
0x4187fc08            [    ] FRAME: [LP] delta=3, fast function #170
0x4187fc00            [    ] VALUE: string "app/server.lua:115: bad argument #1 to 'tenegare' (cdata expected, got number)" @ 0x40831ed8
0x4187fbf8            [    ] VALUE: string "app/server.lua:115: bad argument #1 to 'tenegare' (cdata expected, got number)" @ 0x40831ed8
0x4187fbf0            [    ] FRAME: [C] delta=5, Lua function @ 0x407a1948, 5 upvalues, "@/app/eh.lua":21
0x4187fbe8            [    ] VALUE: string "bad argument #1 to 'tenegare' (cdata expected, got number)" @ 0x40680188
0x4187fbe0            [    ] VALUE: string "cdata expected, got number" @ 0x40680150
0x4187fbd8            [    ] VALUE: cdata @ 0x40e593e0
0x4187fbd0            [    ] VALUE: number 1
0x4187fbc8            [    ] FRAME: [LP] delta=6, fast function #170
0x4187fbc0            [    ] VALUE: nil
0x4187fbb8            [    ] VALUE: number 1
0x4187fbb0            [    ] VALUE: table @ 0x4060fdb0 (asize: 3, hmask: 0x0)
0x4187fba8            [    ] VALUE: table @ 0x40245480 (asize: 0, hmask: 0xf)
0x4187fba0            [    ] VALUE: table @ 0x41635658 (asize: 0, hmask: 0x7)
0x4187fb98            [    ] FRAME: [PP] delta=2, Lua function @ 0x40b35b88, 11 upvalues, "@/app/server.lua":98
0x4187fb90            [    ] VALUE: Lua function @ 0x407a1948, 5 upvalues, "@/app/server.lua":21
0x4187fb88            [    ] FRAME: [LP] delta=11, fast function #21
0x4187fb80            [    ] VALUE: table @ 0x4078d188 (asize: 0, hmask: 0x1)
0x4187fb78            [    ] VALUE: string "123456789" @ 0x410c1058
0x4187fb70            [    ] VALUE: table @ 0x410b2f28 (asize: 0, hmask: 0x3)
0x4187fb68            [    ] VALUE: Lua function @ 0x408202b0, 2 upvalues, "@/app/util.lua":51
0x4187fb60            [    ] VALUE: nil
0x4187fb58            [    ] VALUE: nil
0x4187fb50            [    ] VALUE: table @ 0x4078d188 (asize: 0, hmask: 0x1)
0x4187fb48            [    ] VALUE: Lua function @ 0x40b35b88, 11 upvalues, "@/app/server.lua":98
0x4187fb40            [    ] VALUE: string "123456789" @ 0x410c1058
0x4187fb38            [    ] VALUE: table @ 0x410b2f28 (asize: 0, hmask: 0x3)
0x4187fb30            [    ] FRAME: [LP] delta=6, Lua function @ 0x40820318, 5 upvalues, "@/app/util.lua":64
0x4187fb28            [    ] VALUE: table @ 0x410b2ef0 (asize: 2, hmask: 0x0)
0x4187fb20            [    ] VALUE: string "00000000-0000-0000-0000-000000000000" @ 0x400f47e0
0x4187fb18            [    ] VALUE: string "123456789" @ 0x410c1058
0x4187fb10            [    ] VALUE: table @ 0x40d47198 (asize: 0, hmask: 0x7)
0x4187fb08            [    ] VALUE: table @ 0x410b2f28 (asize: 0, hmask: 0x3)
0x4187fb00            [    ] FRAME: [PP] delta=2, Lua function @ 0x419fca40, 10 upvalues, "@/app/server.lua":93
0x4187faf8            [    ] VALUE: Lua function @ 0x40b35b38, 5 upvalues, "@/app/eh.lua":21
0x4187faf0            [    ] FRAME: [LP] delta=5, fast function #21
0x4187fae8            [    ] VALUE: cdata @ 0x410b3c10
0x4187fae0            [    ] VALUE: cdata @ 0x40f0daa0
0x4187fad8            [    ] VALUE: table @ 0x410b2f28 (asize: 0, hmask: 0x3)
0x4187fad0            [    ] VALUE: table @ 0x40d47198 (asize: 0, hmask: 0x7)
0x4187fac8            [    ] FRAME: [C] delta=1, Lua function @ 0x41d33d10, 11 upvalues, "@/app/init.lua":93
0x4187fac0            [    ] FRAME: [CP] delta=1, C function @ 0x4e708f
0x4187fab8            [S   ] FRAME: dummy L
```

One can find below the code snippets equivalent to the project sources, cause I can't disclose them as is.

* `/app/server.lua`
```lua
-- this function is defined on line 84.
local function tenegare(n)
  local tab = {}
  for i = 1, n do
    work()
  end

  return tab
end

-- this function is defined on line 93
function handler(param1, param2)
  local arg1 = get_arg(param1, 'arg1')
  local arg2 = get_arg(param1, 'arg2')
  local arg3 = get_arg(param1, 'arg3')

  util.do(request, arg1, function()
    local tab1 = make_tab1(arg1)

    -- comment
    local tab2 = make_tab2(tab1, arg2, arg3)

    if something_that_is_false_this_time then
            -- comment
            do(param1, { misc.args }, tab1.key1, tab2.key2)
            return
    end

    -- comment
    local tab3, var1 = make_tab3_and_var1(param1, tab1, arg3)

    local var2
    if var1 ~= 0 then
            var2 = tenegare(var1)
    end
    -- there is unrelated code below
  )
  -- remaining unrelated code
end
```
* `/app/eh.lua`
```lua
local fiber = require 'fiber'
local config = require 'config'
local ffi = require 'ffi'


local function fdef(fn,def)
  if not pcall(function(fn) local t = ffi.C[fn] end, fn) then
    ffi.cdef(def)
  end
end
fdef('abort',   [[ void abort(void); ]])

local M = {}

local last_traceback_time = 0

-- returns an error handler for xpcall
-- error handler logs the traceback and rethrows the error
-- traceback logging is rate limited
function M.error_handler(log)
  return function(e)
    if type(e) == 'cdata' and e[1] then
      return e
    end
    if config.get('suicide') == 'true' then
      local str = tostring(e)
      if str and str:find('expected, got') then
        ffi.C.abort()
      end
    end
    if fiber.time() - last_traceback_time >= 1 then
      last_traceback_time = fiber.time()
      log:error(debug.traceback())
    end
    return e
  end
end

return M
```

Considering the error raised, there is an invalid argument passed to `fast function #170` also known as `<lj_cf_ffi_meta___call>` on the Lua stack slot at 0x4187fbc8. This frame is `LUA` type, so there is `PC` where Lua VM proceed execution when it returns to the parent frame.

```
(gdb) x/2w 0x4187fbc8
0x4187fbc8:     0x40aa3420      0x41cb19f4
(gdb) p/x *(GCfunc *)0x40aa3420
$59 = {c = {nextgc = {gcptr32 = 0x40aa33f8}, marked = 0x1, gct = 0x8, ffid = 0xaa, nupvalues = 0x0, env = {gcptr32 = 0x40a9a9f8}, gclist = {gcptr32 = 0x40aa34e8}, pc = {ptr32 = 0x40a994c8}, f = 0x5ab1f0, upvalue = {{u64 = 0x2b, n = 0x0, {{gcr = {gcptr32 = 0x2b}, i = 0x2b}, it = 0x0}, fr = {func = {gcptr32 = 0x2b}, tp = {ftsz = 0x0, pcr = {ptr32 = 0x0}}}, u32 = {lo = 0x2b, hi = 0x0}}}}, l = {nextgc = {gcptr32 = 0x40aa33f8}, marked = 0x1, gct = 0x8, ffid = 0xaa, nupvalues = 0x0, env = {gcptr32 = 0x40a9a9f8}, gclist = {gcptr32 = 0x40aa34e8}, pc = {ptr32 = 0x40a994c8}, uvptr = {{gcptr32 = 0x0}}}}
(gdb) x/4b ((BCIns *)0x41cb19f4 - 1)
0x41cb19f0:     0x42    0x05    0x02    0x02
(gdb) x/4b ((BCIns *)0x41cb19f4 - 2)
0x41cb19ec:     0x12    0x06    0x03    0x00
(gdb) x/4b ((BCIns *)0x41cb19f4 - 3)
0x41cb19e8:     0x2d    0x05    0x0a    0x00
```

So this is the call of `<tenegare>` function with one argument and one return value. But we see no `<tenegare>` call, but rather `<lj_cf_ffi_meta___call>`. Let's leave digging guest stack a bit and take a look on the host one.

The frame to start digging is the last but one VM frame (i.e. `#18`): Lua code execution stopped in scope of `BC_TNEW`. If we rewind bytecodes a bit we will find the function entry and its prototype:
```
(gdb) f 18
#18 0x0000000000540a2c in lj_BC_TNEW () at buildvm_x86.dasc:556
556     buildvm_x86.dasc: No such file or directory.
(gdb) x/4b ((BCIns*)$rbx - 1)
0x400b2584:     0x34    0x01    0x00    0x00
(gdb) x/4b ((BCIns*)$rbx - 2)
0x400b2580:     0x59    0x0a    0x00    0x00
(gdb) p/x *((GCproto *)((BCIns*)$rbx - 2) - 1)
$1 = {nextgc = {gcptr32 = 0x410b88c8}, marked = 0x1, gct = 0x7, numparams = 0x1, framesize = 0xa, sizebc = 0x12, gclist = {gcptr32 = 0x419fca00}, k = {ptr32 = 0x400b25e0}, uv = {ptr32 = 0x400b25e0}, sizekgc = 0x6, sizekn = 0x0, sizept = 0xca, sizeuv = 0x0, flags = 0x20, trace = 0x0, chunkname = {gcptr32 = 0x41a10838}, firstline = 0x54, numline = 0x7, lineinfo = {ptr32 = 0x400b25e0}, uvinfo = {ptr32 = 0x400b25f1}, varinfo = {ptr32 = 0x400b25f1}}
```

After examining the chunkname field, it occurred the function being currently executed by VM is <tenegare> (defined in /app/server.lua:84). However we don't see it in the Lua stack dump.

OK, we see that the frames above (from `#17` to `#14`) relate to GC machinery, or rather its part responsible for object finalization. Examining the object to be finalized in frame `#14` we see that it's a GCcdata object:
```
(gdb) p/x *(GCcdata *)0x40e593e0
$2 = {nextgc = {gcptr32 = 0x40e59490}, marked = 0x9, gct = 0xa, ctypeid = 0x2b8}
```

Well, I manually resolve the ctype links to obtain the "source" type, and the result is the following:
```
(gdb) p/x CTID_STRUCT_ITERATOR_REF
$3 = 0x2b8
```

So this is `"struct iterator&"` and [here](https://github.com/tarantool/tarantool/blob/master/src/box/lua/schema.lua#L41) one can see its finalizer. Unfortunately, *there is no other way* to examine the called GC object from the optimized code.

OK, if we proceed the investigation in frame `#13`, assuming this GCcdata object is "pcall-ed" within `<gc_call_finalizer>` routine we landed at first in `<lj_vm_pcall>` pad in vm_x86.dasc, and later proceed to `<lj_vmeta_call>` label, since the object to be called is not `LJ_TFUNC` type.

Many thanks for manually spilling `RA` and `RC`, so I can dig the issue to the end. Here is the cframe for this VM frame:
```
(gdb) x/80b $rsp
0x7f324187fa90: 0x02    0x00    0x00    0x00    0x03    0x00    0x00    0x00
0x7f324187fa98: 0x00    0x00    0x00    0x00    0x00    0x00    0x00    0x00
0x7f324187faa0: 0x01    0x00    0x00    0x00    0xff    0xff    0xff    0xff
0x7f324187faa8: 0xb0    0xad    0xdb    0x40    0x5d    0x00    0x00    0x00
0x7f324187fab0: 0xd0    0xfb    0x87    0x41    0x32    0x7f    0x00    0x00
0x7f324187fab8: 0xb4    0x9d    0x31    0x00    0x00    0x00    0x00    0x00
0x7f324187fac0: 0xe0    0x25    0x0b    0x40    0x00    0x00    0x00    0x00
0x7f324187fac8: 0xb8    0x93    0xa9    0x40    0x00    0x00    0x00    0x00
0x7f324187fad0: 0x00    0xfb    0x87    0x41    0x32    0x7f    0x00    0x00
0x7f324187fad8: 0xcc    0x39    0x54    0x00    0x00    0x00    0x00    0x00
```

One can see that `TMP2` (where `RA` is saved) is not a valid "new base" address, but kinda `MULTIRES` value. However, this stack slot is not accessed if the execution proceeds to `<ins_call>`. So I checked what is the "marker" value stored in `KBASE`. Thanks again, it is saved in `SAVE_CFRAME` (the 5th line in LE order from the top of the cframe dumped above). The `BASE` for this frame points to 0x4187fbd0, where <tenegare> argument is stored.

Here it is: as a result of comparing lower 32 bits of `KBASE` and `BASE` values, the execution hits `je ->BC_CALLT_Z` branch, however another branch is expected.

As I mentioned above, I see no similar hacks for other arches and I guess such clashing can occur only for x86_64 build with `LJ_GC64` mode disabled, so I fixed only this case.

---

Relates to tarantool/tarantool#4518
Relates to tarantool/tarantool#4649

Signed-off-by: Igor Munkin <imun@cpan.org>