### PR TITLE
Added fuzzer to integrate into OSS-fuzz

### DIFF
--- a/fuzzing/README.md
+++ b/fuzzing/README.md
@@ -1,0 +1,3 @@
+The fuzzers in this directory run on the OSS-fuzz platform.
+
+`build.sh` is only meant to be used by OSS-fuzz and is hosted here for convenience of updating and/or fixing the build.

--- a/fuzzing/build.sh
+++ b/fuzzing/build.sh
@@ -1,0 +1,29 @@
+#!/bin/bash -eu
+
+# Tests during compilation contain a memory leak,
+# so we switch of detection
+export ASAN_OPTIONS=detect_leaks=0
+
+make BUILDMODE=static \
+	DEFAULT_CC="${CC}" \
+	CFLAGS="${CFLAGS}" \
+	HOST_CC="${CC}" \
+	HOST_CFLAGS="${CFLAGS}" \
+	FUZZ_CFLAGS="${CFLAGS}" \
+	LDFLAGS="" \
+	HOST_LDFLAGS="" \
+	-j$(nproc)
+
+# Build .a file with all .o files
+find . -name "*.o" -exec ar rcs fuzz_lib.a {} \;
+
+# Build the fuzzer
+$CC $CFLAGS -c fuzzer.c -o fuzzer.o -O2 -I. -I./src \
+	-DLUAJIT_TARGET=LUAJIT_ARCH_x64 \
+	-DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE fuzzer.o -o $OUT/fuzzer \
+	-O2 -I. -DLUAJIT_TARGET=LUAJIT_ARCH_x64 \
+	-DLJ_ARCH_HASFPU=1 -DLJ_ABI_SOFTFP=0 \
+	./src/libluajit.a fuzz_lib.a
+

--- a/fuzzing/fuzzer.c
+++ b/fuzzing/fuzzer.c
@@ -1,0 +1,51 @@
+/*
+** LuaJIT -- a Just-In-Time Compiler for Lua. https://luajit.org/
+**
+** Copyright (C) 2020 Mike Pall. All rights reserved.
+**
+** Permission is hereby granted, free of charge, to any person obtaining
+** a copy of this software and associated documentation files (the
+** "Software"), to deal in the Software without restriction, including
+** without limitation the rights to use, copy, modify, merge, publish,
+** distribute, sublicense, and/or sell copies of the Software, and to
+** permit persons to whom the Software is furnished to do so, subject to
+** the following conditions:
+**
+** The above copyright notice and this permission notice shall be
+** included in all copies or substantial portions of the Software.
+**
+** THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+** EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+** MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+** IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+** CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+** TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+** SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+**
+** [ MIT license: https://www.opensource.org/licenses/mit-license.php ]
+*/
+
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include "lauxlib.h"
+#include "lua.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size){
+	char *input_testcase = (char *)malloc(size+1);
+	if (input_testcase == NULL){
+		return 0;
+	}
+	memcpy(input_testcase, data, size);
+	new_str[size] = '\0';
+	
+	lua_State *L = luaL_newstate();
+	
+	luaL_loadstring(L, input_testcase);
+	lua_pcall(L, 0, 1, 0);	
+	
+	lua_close(L);
+	
+	free(input_testcase);
+	return 0;
+}

--- a/src/Makefile
+++ b/src/Makefile
@@ -632,7 +632,7 @@ depend:
 
 $(MINILUA_T): $(MINILUA_O)
 	$(E) "HOSTLINK  $@"
-	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
+	$(Q)$(HOST_CC) $(FUZZ_CFLAGS) $(HOST_ALDFLAGS) -o $@ $(MINILUA_O) $(MINILUA_LIBS) $(HOST_ALIBS)
 
 host/buildvm_arch.h: $(DASM_DASC) $(DASM_DEP) $(DASM_DIR)/*.lua lj_arch.h lua.h luaconf.h
 	$(E) "DYNASM    $@"
@@ -642,7 +642,7 @@ host/buildvm.o: $(DASM_DIR)/dasm_*.h
 
 $(BUILDVM_T): $(BUILDVM_O)
 	$(E) "HOSTLINK  $@"
-	$(Q)$(HOST_CC) $(HOST_ALDFLAGS) -o $@ $(BUILDVM_O) $(HOST_ALIBS)
+	$(Q)$(HOST_CC) $(FUZZ_CFLAGS) $(HOST_ALDFLAGS) -o $@ $(BUILDVM_O) $(HOST_ALIBS)
 
 $(LJVM_BOUT): $(BUILDVM_T)
 	$(E) "BUILDVM   $@"
@@ -712,7 +712,7 @@ $(LUAJIT_SO): $(LJVMCORE_O)
 
 $(LUAJIT_T): $(TARGET_O) $(LUAJIT_O) $(TARGET_DEP)
 	$(E) "LINK      $@"
-	$(Q)$(TARGET_LD) $(TARGET_ALDFLAGS) -o $@ $(LUAJIT_O) $(TARGET_O) $(TARGET_ALIBS)
+	$(Q)$(TARGET_LD) $(TARGET_ALDFLAGS) $(FUZZ_CFLAGS) -o $@ $(LUAJIT_O) $(TARGET_O) $(TARGET_ALIBS)
 	$(Q)$(TARGET_STRIP) $@
 	$(E) "OK        Successfully built LuaJIT"
 


### PR DESCRIPTION
This PR adds a fuzzer with build script to integrate LuaJIT into OSS-fuzz.

I have the build files ready for the oss-fuzz side as well, and will commit those shortly as draft on the OSS-fuzz side.

Integrating into OSS-fuzz will allow the fuzzer in this PR as well as future fuzzers to run continuously through OSS-fuzz. This is a free service offered by Google for critical open source security projects - with an implied expectation that bugs are fixed so that the resources spent on fuzzing LuaJIT go towards resolving bugs in the codebase and not just finding them.

Recently Lua was integrated into OSS-fuzz, and there may be overlaps in code coverage between fuzzing LuaJIT and fuzzing Lua. However it might be a benefit for the LuaJIT maintainers to have fuzzers for the LuaJIT project and receive reports directly instead of depending on maintainers from other projects report their findings. 

The current fuzzer is simple but covers around 15% of the code in the src/ dir which is decent for a first fuzzer. It is my opinion that this PR is a good start to getting continuous fuzzing set up for LuaJIT. Improvements can be made to the fuzzer in this PR and to improve the total coverage of LuaJIT, and the files in this PR will make future work easy.

If you have any comments about the files in this PR please do not hesitate to bring them up. The setup should make it easy for maintainers to carry on the work.