### PR TITLE
FFI: Fix compilation of union initialization

### DIFF
--- a/src/lj_crecord.c
+++ b/src/lj_crecord.c
@@ -959,6 +959,7 @@ static void crec_alloc(jit_State *J, RecordFFData *rd, CTypeID id)
 	  dp = emitir(IRT(IR_ADD, IRT_PTR), trcd,
 		      lj_ir_kintp(J, df->size + sizeof(GCcdata)));
 	  crec_ct_tv(J, dc, dp, sp, sval);
+	  if ((d->info & CTF_UNION)) break;
 	} else if (!ctype_isconstval(df->info)) {
 	  /* NYI: init bitfields and sub-structures. */
 	  lj_trace_err(J, LJ_TRERR_NYICONV);


### PR DESCRIPTION
Issue #128 was an actual miscompile, not a JIT limitation, contrary to @CapsAdmin’s comments and your decision to close it as a duplicate of #20. To recapitulate:
``` lua
local ffi = require "ffi"
--[[1]] --local tfu = ffi.typeof[[ union { uint32_t u; } ]]
--[[2]] local tfu = ffi.typeof[[ union { uint32_t u; float f; } ]]

for u = 1, 2^16-1 do
	if tfu(u).u ~= u then error(u .. " " .. tfu(u).u) end
end
```
runs fine if line `[1]` is enabled or if JIT is off, but exits with an error (containing two identical numbers!) if line `[2]` is enabled and JIT is on. This happens both on master and on v2.1.

The bug is essentially the same as the one fixed by 41156fe, except in the trace recorder instead of the interpreter code: `crec_alloc` was initializing all fields of a union instead of only the first one, as though it were a struct.