### PR TITLE
Fix unwind table detection

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -314,12 +314,18 @@ else
 ifeq (,$(shell $(TARGET_CC) -o /dev/null -c -x c /dev/null -fno-stack-protector 2>/dev/null || echo 1))
   TARGET_XCFLAGS+= -fno-stack-protector
 endif
+ifeq (,$(findstring LJ_NO_UNWIND 1,$(TARGET_TESTARCH)))
+  # Find out whether the target toolchain always generates unwind tables.
+  TARGET_TESTUNWIND=$(shell exec 2>/dev/null; echo 'extern void b(void);int a(void){b();return 0;}' | $(TARGET_CC) -c -x c - -o tmpunwind.o && grep -qU -e eh_frame -e __unwind_info tmpunwind.o && echo E; rm -f tmpunwind.o)
+  ifneq (,$(findstring E,$(TARGET_TESTUNWIND)))
+    TARGET_XCFLAGS+= -DLUAJIT_UNWIND_EXTERNAL
+  endif
+endif
 ifeq (Darwin,$(TARGET_SYS))
   ifeq (,$(MACOSX_DEPLOYMENT_TARGET))
     $(error missing: export MACOSX_DEPLOYMENT_TARGET=XX.YY)
   endif
   TARGET_STRIP+= -x
-  TARGET_XCFLAGS+= -DLUAJIT_UNWIND_EXTERNAL
   TARGET_XSHLDFLAGS= -dynamiclib -single_module -undefined dynamic_lookup -fPIC
   TARGET_DYNXLDOPTS=
   TARGET_XSHLDFLAGS+= -install_name $(TARGET_DYLIBPATH) -compatibility_version $(MAJVER).$(MINVER) -current_version $(MAJVER).$(MINVER).$(RELVER)
@@ -333,13 +339,6 @@ ifeq (iOS,$(TARGET_SYS))
     TARGET_XCFLAGS+= -fno-omit-frame-pointer
   endif
 else
-  ifeq (,$(findstring LJ_NO_UNWIND 1,$(TARGET_TESTARCH)))
-    # Find out whether the target toolchain always generates unwind tables.
-    TARGET_TESTUNWIND=$(shell exec 2>/dev/null; echo 'extern void b(void);int a(void){b();return 0;}' | $(TARGET_CC) -c -x c - -o tmpunwind.o && grep -qa -e eh_frame -e __unwind_info tmpunwind.o && echo E; rm -f tmpunwind.o)
-    ifneq (,$(findstring E,$(TARGET_TESTUNWIND)))
-      TARGET_XCFLAGS+= -DLUAJIT_UNWIND_EXTERNAL
-    endif
-  endif
   ifneq (SunOS,$(TARGET_SYS))
     ifneq (PS3,$(TARGET_SYS))
       TARGET_XLDFLAGS+= -Wl,-E


### PR DESCRIPTION
This reinstates the original test, but uses the flags `-qU` instead of
`-qa` with `grep`.

This allows the test to work for both GNU and BSD grep (tested locally).

Follow up to #677.