### PR TITLE
OSX/ARM64: fix variadic arguments handling in FFI

### DIFF
--- a/src/lj_ccall.c
+++ b/src/lj_ccall.c
@@ -334,7 +334,7 @@
   isfp = sz == 2*sizeof(float) ? 2 : 1;
 
 #define CCALL_HANDLE_REGARG \
-  if (LJ_TARGET_IOS && isva) { \
+  if (LJ_TARGET_OSX && isva) { \
     /* IOS: All variadic arguments are on the stack. */ \
   } else if (isfp) {  /* Try to pass argument in FPRs. */ \
     int n2 = ctype_isvector(d->info) ? 1 : \
@@ -345,10 +345,10 @@
       goto done; \
     } else { \
       nfpr = CCALL_NARG_FPR;  /* Prevent reordering. */ \
-      if (LJ_TARGET_IOS && d->size < 8) goto err_nyi; \
+      if (LJ_TARGET_OSX && d->size < 8) goto err_nyi; \
     } \
   } else {  /* Try to pass argument in GPRs. */ \
-    if (!LJ_TARGET_IOS && (d->info & CTF_ALIGN) > CTALIGN_PTR) \
+    if (!LJ_TARGET_OSX && (d->info & CTF_ALIGN) > CTALIGN_PTR) \
       ngpr = (ngpr + 1u) & ~1u;  /* Align to regpair. */ \
     if (ngpr + n <= maxgpr) { \
       dp = &cc->gpr[ngpr]; \
@@ -356,7 +356,7 @@
       goto done; \
     } else { \
       ngpr = maxgpr;  /* Prevent reordering. */ \
-      if (LJ_TARGET_IOS && d->size < 8) goto err_nyi; \
+      if (LJ_TARGET_OSX && d->size < 8) goto err_nyi; \
     } \
   }
 

--- a/src/lj_ccallback.c
+++ b/src/lj_ccallback.c
@@ -414,7 +414,7 @@ void lj_ccallback_mcode_free(CTState *cts)
       nfpr = CCALL_NARG_FPR;  /* Prevent reordering. */ \
     } \
   } else { \
-    if (!LJ_TARGET_IOS && n > 1) \
+    if (!LJ_TARGET_OSX && n > 1) \
       ngpr = (ngpr + 1u) & ~1u;  /* Align to regpair. */ \
     if (ngpr + n <= maxgpr) { \
       sp = &cts->cb.gpr[ngpr]; \


### PR DESCRIPTION
This patch fixes the issue introduced by commit 2e2fb8f6b5118e1a7996b76600c6ee98bfd5f203 ('OSX/iOS: Handle iOS simulator and ARM64 Macs.'). Within the mentioned commit LJ_TARGET_IOS define is set via Apple system header to enable several features (e.g. JIT and external unwinder) on ARM64 Macs, but it's usage was not adjusted source-wide. This is done for FFI machinery within this commit.

Since all LJ_TARGET_IOS usage is done with LJ_TARGET_ARM64 define being set, we can simply replace all occurences with LJ_TARGET_OSX.

---

Consider the following test.
```lua
local ffi = require('ffi')
ffi.cdef('int printf(const char *format, ...)')
ffi.C.printf('try vararg function: %s:%f(%d) - %llu\n', 'imun', 9, 9LL, -1ULL)
```
And the proof below.
```bash
$ uname -mrs
Darwin 20.3.0 arm64
$ git describe
v2.1.0-beta3-257-g75ee3a61
$ make -j
<snipped>
$ ./src/luajit test.lua 
try vararg function: ��6k:0.000000(6) - 4373511296
$ git checkout v2.1
Previous HEAD position was 75ee3a61 Prevent compile of __concat with tailcall to fast function.
Switched to branch 'v2.1'
Your branch is up to date with 'origin/v2.1'.
$ make -j
==== Building LuaJIT 2.1.0-beta3 ====
/Library/Developer/CommandLineTools/usr/bin/make -C src
CC        lj_ccall.o
CC        lj_ccallback.o
AR        libluajit.a
DYNLINK   libluajit.so
LINK      luajit
OK        Successfully built LuaJIT
==== Successfully built LuaJIT 2.1.0-beta3 ====
$ ./src/luajit test.lua
try vararg function: imun:9.000000(9) - 18446744073709551615
```

---

Reported-by: Nikita Pettik <korablev@tarantool.org>
Signed-off-by: Igor Munkin <imun@cpan.org>