### PR TITLE
bugfix: lua stack is broken when trace abort during recording nyi stitch.

### DIFF
--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -107,6 +107,11 @@ static void recff_stitch(jit_State *J)
   const BCIns *pc = frame_pc(base-1);
   TValue *pframe = frame_prevl(base-1);
 
+  MSize maxsnap = (MSize)J->param[JIT_P_maxsnap];
+  MSize nsnap = J->cur.nsnap;
+  if (nsnap >= maxsnap)
+    lj_trace_err_info(J, LJ_TRERR_SNAPOV);
+
   /* Move func + args up in Lua stack and insert continuation. */
   memmove(&base[1], &base[-1-LJ_FR2], sizeof(TValue)*nslot);
   setframe_ftsz(nframe, ((char *)nframe - (char *)pframe) + FRAME_CONT);


### PR DESCRIPTION
The lua stack will broken when trace abort in `lj_record_stop` like reach the `maxsnap` since the lua stack is changed before [lj_record_stop](https://github.com/LuaJIT/LuaJIT/blob/v2.1/src/lj_ffrecord.c#L133).

Here is an example lua script to reproduce this bug by using the `v2.1` branch.
```
$ make
$ ./src/luajit t.lua
Segmentation fault (core dumped)
```

```
require "jit.opt".start("hotloop=2", "hotexit=1", "maxsnap=8")

local m = 1

local function foo(n)
    m = m + n
    if n >= 2 then
        m = m * n
    end
end

foo(1); foo(1); foo(1); foo(1); foo(1); foo(1);

local tb = {
    foo = 1,
    bar = 2,
}

local function bar()
    for i = 2, 3 do
        foo(i);
    end

    tb.foo = 10

    print(tb.foo)
end

bar()

print(m)
```

This PR is a temporary fix, but it works for the example lua script.
Maybe the proper way is to fix it in `err_unwind`?