### PR TITLE
Flush profile into file

### DIFF
--- a/src/jit/p.lua
+++ b/src/jit/p.lua
@@ -238,6 +238,7 @@ local function prof_finish()
     prof_count1 = nil
     prof_count2 = nil
     prof_ud = nil
+    if out ~= stdout then out:close() end
   end
 end
 


### PR DESCRIPTION
Using jit.p:start() with a file argument does not flush result to the file.
It's Ok when used from command line, still it's a hurdle for runtime invocation.