### PR TITLE
Fix cur_L restoration on error throw

### DIFF
--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -735,6 +735,8 @@ LJ_NOINLINE void LJ_FASTCALL lj_err_throw(lua_State *L, int errcode)
 {
   global_State *g = G(L);
   lj_trace_abort(g);
+  /* Set the running lua_State as the one where the error can be handled. */
+  setgcref(g->cur_L, obj2gco(L));
   L->status = LUA_OK;
 #if LJ_UNWIND_EXT
   err_raise_ext(g, errcode);


### PR DESCRIPTION
Raising an error on the coroutine different from the `cur_L` leads to Lua stack inconsistency during snapshot restoration at trace exit.

Assume we have some C module named libcur_L, that can raise an error not from the `cur_L` coroutine.
```c
#include <lua.h>
#include <lauxlib.h>

static lua_State *old_L = NULL;

static int throw_error_at_old_thread(lua_State *cur_L)
{
	lua_error(old_L);
	/* Unreachable. */
	return 0;
}

static int error_from_other_thread(lua_State *L)
{
	old_L = L;
	lua_State *next_cur_L = lua_newthread(L);
	/* Remove thread. */
	lua_pop(L, 1);
	/* Do not show frame slot as return result after error. */
	lua_pushnil(L);
	lua_pushcfunction(next_cur_L, throw_error_at_old_thread);
	lua_call(next_cur_L, 0, 0);
	/* Unreachable. */
	return 0;
}

static const struct luaL_Reg libcur_L[] = {
	{"error_from_other_thread", error_from_other_thread},
	{NULL, NULL}
};

LUA_API int luaopen_libcur_L(lua_State *L)
{
	luaL_register(L, "libcur_L", libcur_L);
	return 1;
}
```

Compile it like the following for LuaJIT and Lua correspondingly:
```bash
$ gcc -O0 -ggdb3 -L$HOME/LuaJIT/src -lluajit -I$HOME/LuaJIT/src -fPIC --shared -o libcur_L.so libcur_L.c
$ gcc -O0 -ggdb3 -L$HOME/lua        -llua    -I$HOME/lua        -fPIC --shared -o libcur_L.so libcur_L.c
```

Also, we need to invoke `error_from_other_thread()` before calling some compiled function, which may lead to Lua state restoration from a snapshot.

The example file named cur_L.test.lua
```lua
local libcur_L = require('libcur_L')

local function onesnap_f(var)
  if var then
    return 1
  else
    return 0
  end
end

-- Compile function to trace with snapshot.
if jit then jit.opt.start('hotloop=1') end
onesnap_f(true)
onesnap_f(true)

local r, s = pcall(libcur_L.error_from_other_thread)
onesnap_f(false)
```

If one runs this test for LuaJIT (JIT on/off) and Lua he gets the following results:
```bash
$ LUA_PATH="$HOME/LuaJIT/src/?.lua;;" LD_LIBRARY_PATH=$HOME/LuaJIT/src $HOME/LuaJIT/src/luajit -jon cur_L.test.lua 
Segmentation fault

$ LUA_PATH="$HOME/LuaJIT/src/?.lua;;" LD_LIBRARY_PATH=$HOME/LuaJIT/src $HOME/LuaJIT/src/luajit -joff cur_L.test.lua

$ LD_LIBRARY_PATH=$HOME/lua $HOME/lua/lua cur_L.test.lua
```

This problem was originally reported by Nick Zavaritsky [here](https://www.freelists.org/post/luajit/Issue-with-PCALL-in-21).
