### PR TITLE
x86/x64/FFI: Make FP to U64 conv match JIT backend

### DIFF
--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -1004,7 +1004,7 @@ static LJ_AINLINE int32_t lj_num2bit(lua_Number n)
 */
 static LJ_AINLINE uint64_t lj_num2u64(lua_Number n)
 {
-#if LJ_TARGET_X86ORX64 || LJ_TARGET_MIPS
+#if LJ_TARGET_MIPS
   int64_t i = (int64_t)n;
   if (i < 0) i = (int64_t)(n - 18446744073709551616.0);
   return (uint64_t)i;


### PR DESCRIPTION
How I built:
```bash
$ make -j CFLAGS=" -O0 " CCDEBUG=" -g -ggdb3" XCFLAGS=" -DLUA_USE_APICHECK -DLUA_USE_ASSERT"
```

The test case:
```lua
local ffi = require "ffi"
local t = {}
table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
jit.opt.start(0, "hotloop=1")
for _ = 1, 4 do
    table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
end
for i = 1, 5 do print(t[i]) end
```

Before patch:
```bash
$ ./luajit -e '
local ffi = require "ffi"
local t = {}
table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
jit.opt.start(0, "hotloop=1")
for _ = 1, 4 do
    table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
end
for i = 1, 5 do print(t[i]) end
'
9.2233720368548e+18
9.2233720368548e+18
9.2233720368548e+18
9.2233720368548e+18
1.844674407371e+19
```

And with optimizations I have the following assert:
```
LuaJIT ASSERT lj_record.c:168: rec_check_slots: slot 11 const mismatch: stack 43e0000000000000 vs IR 43f0000000000000
```

gcc version 9.3.0.

Aftet patch:
```bash
$ ./luajit -e '
local ffi = require "ffi"
local t = {}
table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
jit.opt.start(0, "hotloop=1")
for _ = 1, 4 do
    table.insert(t, tonumber(ffi.cast("uint64_t", -1)))
end
for i = 1, 5 do print(t[i]) end
'
1.844674407371e+19
1.844674407371e+19
1.844674407371e+19
1.844674407371e+19
1.844674407371e+19
```

Checked my patch also on Windows with MSVC 16.7.6.
