### PR TITLE
Fix simplify_numsub_k fold rule

### DIFF
--- a/src/lj_opt_fold.c
+++ b/src/lj_opt_fold.c
@@ -1038,8 +1038,15 @@ LJFOLD(SUB any KNUM)
 LJFOLDF(simplify_numsub_k)
 {
   lua_Number n = knumright;
-  if (n == 0.0)  /* x - (+-0) ==> x */
-    return LEFTFOLD;
+  if (n == 0.0) {
+    /* x - (+0) ==> x */
+    if (!signbit(n))
+      return LEFTFOLD;
+    /* x - (-0) ==> x + 0 */
+    /* Note: x + 0 != x for x = -0 */
+    fins->o = IR_ADD;
+    fins->op2 = (IRRef1)lj_ir_knum(J, 0.0);
+  }
   return NEXTFOLD;
 }
 


### PR DESCRIPTION
The `simplify_numsub_k` fold rule produced wrong results for cases where `n = -0` in which case it optimized `x - (-0)` to `x`. This will produce `-0` for `x = -0`, however, `x - (-0) == x + 0` which should produce `0` for `x = -0`.
The fix checks the sign of n.
If n is positive the calculation can be dropped. If n is negative it is replaced by `x+0` instead.

To test the changes the following test can be used:

```lua
local x = -0
local y = x - (-0)

print(y)

for i = 1, 10000 do
    y = x - (-0)
end

print(y)
```