### PR TITLE
Fix TARGET_AR examples in doc/install.html (v2.1)

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -411,7 +411,7 @@ NDKCROSS=$NDKBIN/aarch64-linux-android-
 NDKCC=$NDKBIN/aarch64-linux-android21-clang
 make CROSS=$NDKCROSS \
      STATIC_CC=$NDKCC DYNAMIC_CC="$NDKCC -fPIC" \
-     TARGET_LD=$NDKCC TARGET_AR=$NDKBIN/llvm-ar
+     TARGET_LD=$NDKCC TARGET_AR="$NDKBIN/llvm-ar rcus" \
      TARGET_STRIP=$NDKBIN/llvm-strip
 
 # Android/ARM, armeabi-v7a (ARMv7 VFP), Android 4.1+ (JB)
@@ -421,7 +421,7 @@ NDKCROSS=$NDKBIN/arm-linux-androideabi-
 NDKCC=$NDKBIN/armv7a-linux-androideabi16-clang
 make HOST_CC="gcc -m32" CROSS=$NDKCROSS \
      STATIC_CC=$NDKCC DYNAMIC_CC="$NDKCC -fPIC" \
-     TARGET_LD=$NDKCC TARGET_AR=$NDKBIN/llvm-ar
+     TARGET_LD=$NDKCC TARGET_AR="$NDKBIN/llvm-ar rcus" \
      TARGET_STRIP=$NDKBIN/llvm-strip
 </pre>
 <p>


### PR DESCRIPTION
Examples in `doc/install.html` to build under Android NDK are overwriting TARGET_AR incorrectly:
https://github.com/LuaJIT/LuaJIT/blob/1d7b5029c5ba36870d25c67524034d452b761d27/doc/install.html#L414
since TARGET_AR in the Makefile is expected to have params:
https://github.com/LuaJIT/LuaJIT/blob/1d7b5029c5ba36870d25c67524034d452b761d27/src/Makefile#L214