### PR TITLE
Fix TARGET_AR example in doc/install.html (v2.0)

### DIFF
--- a/doc/install.html
+++ b/doc/install.html
@@ -380,7 +380,7 @@ NDKCROSS=$NDKBIN/arm-linux-androideabi-
 NDKCC=$NDKBIN/armv7a-linux-androideabi16-clang
 make HOST_CC="gcc -m32" CROSS=$NDKCROSS \
      STATIC_CC=$NDKCC DYNAMIC_CC="$NDKCC -fPIC" \
-     TARGET_LD=$NDKCC TARGET_AR=$NDKBIN/llvm-ar
+     TARGET_LD=$NDKCC TARGET_AR="$NDKBIN/llvm-ar rcus" \
      TARGET_STRIP=$NDKBIN/llvm-strip
 </pre>
 <p>


### PR DESCRIPTION
Examples in doc/install.html to build under Android NDK are overwriting TARGET_AR incorrectly:
https://github.com/LuaJIT/LuaJIT/blob/9ebebc9b588dc1516c988b46d829445f505fdc1f/doc/install.html#L383
since TARGET_AR in the Makefile is expected to have params:
https://github.com/LuaJIT/LuaJIT/blob/9ebebc9b588dc1516c988b46d829445f505fdc1f/src/Makefile#L214