### PR TITLE
fix: remove premature semicolon that prevents attribute application

### DIFF
--- a/src/lj_prng.c
+++ b/src/lj_prng.c
@@ -126,7 +126,7 @@ static PRGR libfunc_rgr;
 #endif
 
 #if LJ_TARGET_HAS_GETENTROPY
-extern int getentropy(void *buf, size_t len);
+extern int getentropy(void *buf, size_t len)
 #ifdef __ELF__
   __attribute__((weak))
 #endif


### PR DESCRIPTION
Compiling on openbsd gives the warning

lj_prng.c:131:3: warning: declaration does not declare anything [-Wmissing-declarations]
  __attribute__((weak))
  ^

This PR fixes the warning.