### PR TITLE
Fix bad lightuserdata segment assertion

### DIFF
--- a/src/lj_obj.h
+++ b/src/lj_obj.h
@@ -845,6 +845,7 @@ static LJ_AINLINE void *lightudV(global_State *g, cTValue *o)
   uint64_t seg = lightudseg(u);
   uint32_t *segmap = mref(g->gc.lightudseg, uint32_t);
   lj_assertG(tvislightud(o), "lightuserdata expected");
+  if (seg == (1 << LJ_LIGHTUD_BITS_SEG)-1) return NULL;
   lj_assertG(seg <= g->gc.lightudnum, "bad lightuserdata segment %d", seg);
   return (void *)(((uint64_t)segmap[seg] << 32) | lightudlo(u));
 }

--- a/src/lj_strfmt.c
+++ b/src/lj_strfmt.c
@@ -521,6 +521,11 @@ GCstr * LJ_FASTCALL lj_strfmt_obj(lua_State *L, cTValue *o)
     return lj_str_newlit(L, "true");
   } else {
     char buf[8+2+2+16], *p = buf;
+    if (tvislightud(o) && o->u32.hi == LJ_KEYINDEX) {
+      p = lj_buf_wmem(p, "iterator@", 9);
+      p = lj_strfmt_wint(p, o->u32.lo);
+      return lj_str_new(L, buf, (size_t)(p - buf));
+    }
     p = lj_buf_wmem(p, lj_typename(o), (MSize)strlen(lj_typename(o)));
     *p++ = ':'; *p++ = ' ';
     if (tvisfunc(o) && isffunc(funcV(o))) {


### PR DESCRIPTION
In cases were Lua debuggers print all variables of a frame it might include the special itern userdata value. On GC64 this value is located in segment 255 which is not allocated and will give an assertion at 
https://github.com/LuaJIT/LuaJIT/blob/e2c312e0deb874aa5fa8ce502c08d87deb38e82f/src/lj_obj.h#L848
with the following script
```lua
for k, v in pairs({a=1}) do
    print(debug.getlocal(1, 3))
end
```

This PR adds a check for this case to `lightudV` and returns `NULL` in case of the special itern key.
Furthermore, it adds a nicer print output for the special key.