### PR TITLE
DynASM/ARM64: Fix LSL encoding with immediate shifts

### DIFF
--- a/dynasm/dasm_arm64.lua
+++ b/dynasm/dasm_arm64.lua
@@ -248,7 +248,7 @@ local map_cond = {
 
 local parse_reg_type
 
-local function parse_reg(expr, shift)
+local function parse_reg(expr, shift, skip_vreg)
   if not expr then werror("expected register name") end
   local tname, ovreg = match(expr, "^([%w_]+):(@?%l%d+)$")
   if not tname then
@@ -281,7 +281,7 @@ local function parse_reg(expr, shift)
     elseif parse_reg_type ~= vrt then
       werror("register size mismatch")
     end
-    if shift then waction("VREG", shift, vreg) end
+    if not skip_vreg then waction("VREG", shift, vreg) end
     return 0
   end
   werror("bad register name `"..expr.."'")
@@ -649,7 +649,7 @@ local function alias_bfiz(p)
 end
 
 local alias_lslimm = op_alias("ubfm_4", function(p)
-  parse_reg(p[1], 0)
+  parse_reg(p[1], 0, true)
   local sh = p[3]:sub(2)
   if parse_reg_type == "w" then
     p[3] = "#(32-("..sh.."))%32"


### PR DESCRIPTION
VREG action for ``LSL Rx(dst), R(src), #imm`` is emitted before the ``LSL`` instruction. As result it's processed before ``LSL`` and modifies the previous instruction. Probably, this fix should be extended to other aliases as well.