### PR TITLE
Fixes the include directory in the pkgconfig file 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,8 @@ INSTALL_F= install -m 0644
 UNINSTALL= $(RM)
 LDCONFIG= ldconfig -n 2>/dev/null
 SED_PC= sed -e "s|^prefix=.*|prefix=$(PREFIX)|" \
-            -e "s|^multilib=.*|multilib=$(MULTILIB)|"
+            -e "s|^multilib=.*|multilib=$(MULTILIB)|" \
+            -e "s|^includedir=.*|includedir=$(INSTALL_INC)|"
 
 FILE_T= luajit
 FILE_A= libluajit.a


### PR DESCRIPTION
When the include file is customized in the make command line, the `includedir` directory still points to the default name. This causes cmake to break due to not finding the include directory in the filesystem and might affect other builders as well.
