### PR TITLE
Compile tonumber calls with bases other than 10

### DIFF
--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -289,31 +289,10 @@ LJLIB_ASM(tonumber)		LJLIB_REC(.)
     }
 #endif
   } else {
-    const char *p = strdata(lj_lib_checkstr(L, 1));
-    char *ep;
-    unsigned int neg = 0;
-    unsigned long ul;
     if (base < 2 || base > 36)
       lj_err_arg(L, 2, LJ_ERR_BASERNG);
-    while (lj_char_isspace((unsigned char)(*p))) p++;
-    if (*p == '-') { p++; neg = 1; } else if (*p == '+') { p++; }
-    if (lj_char_isalnum((unsigned char)(*p))) {
-      ul = strtoul(p, &ep, base);
-      if (p != ep) {
-	while (lj_char_isspace((unsigned char)(*ep))) ep++;
-	if (*ep == '\0') {
-	  if (LJ_DUALNUM && LJ_LIKELY(ul < 0x80000000u+neg)) {
-	    if (neg) ul = (unsigned long)-(long)ul;
-	    setintV(L->base-1-LJ_FR2, (int32_t)ul);
-	  } else {
-	    lua_Number n = (lua_Number)ul;
-	    if (neg) n = -n;
-	    setnumV(L->base-1-LJ_FR2, n);
-	  }
-	  return FFH_RES(1);
-	}
-      }
-    }
+    if (lj_strscan_number_base(lj_lib_checkstr(L, 1), L->base-1-LJ_FR2, base))
+      return FFH_RES(1);
   }
   setnilV(L->base-1-LJ_FR2);
   return FFH_RES(1);

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -355,7 +355,7 @@ static void LJ_FASTCALL recff_tonumber(jit_State *J, RecordFFData *rd)
       if (tref_isstr(tr)) {
         if (tref_isk(tr) && tref_isk(base) && kbase >= 2 && kbase <= 36) {
           TValue out;
-          if (lj_strscan_num_base(strV(&rd->argv[0]), &out, (int)kbase))
+          if (lj_strscan_num_base(strV(&rd->argv[0]), &out, kbase))
             J->base[0] = lj_ir_knum(J, numV(&out));
           else
             J->base[0] = TREF_NIL;

--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -354,19 +354,19 @@ static void LJ_FASTCALL recff_tonumber(jit_State *J, RecordFFData *rd)
     if (!tref_isk(base) || (kbase = IR(tref_ref(base))->i) != 10) {
       if (tref_isstr(tr)) {
         if (tref_isk(tr) && tref_isk(base) && kbase >= 2 && kbase <= 36) {
-          TValue num;
-          if (lj_strscan_num_base(strV(&rd->argv[0]), &num, (int)kbase))
-            J->base[0] = lj_ir_knum(J, numV(&num));
+          TValue out;
+          if (lj_strscan_num_base(strV(&rd->argv[0]), &out, (int)kbase))
+            J->base[0] = lj_ir_knum(J, numV(&out));
           else
             J->base[0] = TREF_NIL;
         } else {
-          TRef tmp, parsed;
+          TRef out, scanned;
           emitir(IRTGI(IR_GE), base, lj_ir_kint(J, 2));
           emitir(IRTGI(IR_LE), base, lj_ir_kint(J, 36));
-          tmp = recff_tmpref(J, TREF_NIL, IRTMPREF_OUT1);
-          parsed = lj_ir_call(J, IRCALL_lj_strscan_num_base, tr, tmp, base);
-          emitir(IRTGI(IR_NE), parsed, lj_ir_kint(J, 0));
-          J->base[0] = lj_record_vload(J, tmp, 0, IRT_NUM);
+          out = recff_tmpref(J, TREF_NIL, IRTMPREF_OUT1);
+          scanned = lj_ir_call(J, IRCALL_lj_strscan_num_base, tr, out, base);
+          emitir(IRTGI(IR_NE), scanned, lj_ir_kint(J, 0));
+          J->base[0] = lj_record_vload(J, out, 0, IRT_NUM);
         }
       } else {
         recff_nyiu(J, rd);

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -155,6 +155,7 @@ typedef struct CCallInfo {
   _(ANY,	lj_str_find,		4,   N, PGC, 0) \
   _(ANY,	lj_str_new,		3,   S, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strscan_num,		2,  FN, INT, 0) \
+  _(ANY,	lj_strscan_num_base,	3,  N, INT, 0) \
   _(ANY,	lj_strfmt_int,		2,  FN, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strfmt_num,		2,  FN, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strfmt_char,		2,  FN, STR, CCI_L|CCI_T) \

--- a/src/lj_ircall.h
+++ b/src/lj_ircall.h
@@ -155,7 +155,7 @@ typedef struct CCallInfo {
   _(ANY,	lj_str_find,		4,   N, PGC, 0) \
   _(ANY,	lj_str_new,		3,   S, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strscan_num,		2,  FN, INT, 0) \
-  _(ANY,	lj_strscan_num_base,	3,  N, INT, 0) \
+  _(ANY,	lj_strscan_num_base,	3,  S, INT, 0) \
   _(ANY,	lj_strfmt_int,		2,  FN, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strfmt_num,		2,  FN, STR, CCI_L|CCI_T) \
   _(ANY,	lj_strfmt_char,		2,  FN, STR, CCI_L|CCI_T) \

--- a/src/lj_strscan.c
+++ b/src/lj_strscan.c
@@ -552,7 +552,7 @@ int LJ_FASTCALL lj_strscan_number(GCstr *str, TValue *o)
 }
 #endif
 
-static int strscan_base(GCstr *str, TValue *o, int base, int dualnum)
+static int32_t strscan_base(GCstr *str, TValue *o, int32_t base, int dualnum)
 {
   const char *p = strdata(str);
   char *ep;
@@ -561,7 +561,7 @@ static int strscan_base(GCstr *str, TValue *o, int base, int dualnum)
   while (lj_char_isspace((unsigned char)(*p))) p++;
   if (*p == '-') { p++; neg = 1; } else if (*p == '+') { p++; }
   if (lj_char_isalnum((unsigned char)(*p))) {
-    ul = strtoul(p, &ep, base);
+    ul = strtoul(p, &ep, (int)base);
     if (p != ep) {
       while (lj_char_isspace((unsigned char)(*ep))) ep++;
       if (*ep == '\0') {
@@ -580,13 +580,13 @@ static int strscan_base(GCstr *str, TValue *o, int base, int dualnum)
   return 0;
 }
 
-LJ_FUNC int lj_strscan_num_base(GCstr *str, TValue *o, int base)
+LJ_FUNC int32_t lj_strscan_num_base(GCstr *str, TValue *o, int32_t base)
 {
   return strscan_base(str, o, base, 0);
 }
 
 #if LJ_DUALNUM
-LJ_FUNC int lj_strscan_number_base(GCstr *str, TValue *o, int base)
+LJ_FUNC int32_t lj_strscan_number_base(GCstr *str, TValue *o, int32_t base)
 {
   return strscan_base(str, o, base, 1);
 }

--- a/src/lj_strscan.h
+++ b/src/lj_strscan.h
@@ -38,9 +38,9 @@ static LJ_AINLINE int lj_strscan_numberobj(TValue *o)
 }
 
 /* The base must be between 2 and 36. */
-LJ_FUNC int lj_strscan_num_base(GCstr *str, TValue *o, int base);
+LJ_FUNC int32_t lj_strscan_num_base(GCstr *str, TValue *o, int32_t base);
 #if LJ_DUALNUM
-LJ_FUNC int lj_strscan_number_base(GCstr *str, TValue *o, int base);
+LJ_FUNC int32_t lj_strscan_number_base(GCstr *str, TValue *o, int32_t base);
 #else
 #define lj_strscan_number_base(s, o, base) \
   lj_strscan_num_base((s), (o), (base))

--- a/src/lj_strscan.h
+++ b/src/lj_strscan.h
@@ -37,4 +37,13 @@ static LJ_AINLINE int lj_strscan_numberobj(TValue *o)
   return tvisnumber(o) || (tvisstr(o) && lj_strscan_number(strV(o), o));
 }
 
+/* The base must be between 2 and 36. */
+LJ_FUNC int lj_strscan_num_base(GCstr *str, TValue *o, int base);
+#if LJ_DUALNUM
+LJ_FUNC int lj_strscan_number_base(GCstr *str, TValue *o, int base);
+#else
+#define lj_strscan_number_base(s, o, base) \
+  lj_strscan_num_base((s), (o), (base))
+#endif
+
 #endif


### PR DESCRIPTION
Note: This is my first contribution to LuaJIT.

It is sometimes necessary to parse numbers with different bases, in which case `tonumber` is NYI. This pull request aims to change that. It mainly just moves some parsing code from `lib_base.c` to `lj_strscan.c`.

An alternative to this change that doesn't require a patch is to append a prefix such as `0x` to numbers before passing them to `tonumber`. I did a speed comparison between that way and the new way:

```lua
if true then -- Set this to false to use the "old" way instead of the new way.
	function hex2num(hex)
		return tonumber(hex, 16)
	end
else
	function hex2num(hex)
		return tonumber('0x' .. hex)
	end
end

local start = os.clock()
local s = 0
for i = 1, 10000000 do
	s = s + hex2num(("%x"):format(i))
end
local finish = os.clock()
print(finish - start, s)

```

Output using the new way:

```
1.729074	50000005000000
```

Output using the "old" way:

```
3.164303	50000005000000
```