### PR TITLE
Specialize to the global environment

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -2456,6 +2456,12 @@ void lj_record_ins(jit_State *J)
   case BC_GGET: case BC_GSET:
     settabV(J->L, &ix.tabv, tabref(J->fn->l.env));
     ix.tab = emitir(IRT(IR_FLOAD, IRT_TAB), getcurrf(J), IRFL_FUNC_ENV);
+    if (gcrefeq(J->fn->l.env, J->L->env)) {
+      /* Specialize to the global environment. */
+      TRef ktab = lj_ir_ktab(J, tabref(J->fn->l.env));
+      emitir(IRTG(IR_EQ, IRT_TAB), ix.tab, ktab);
+      ix.tab = ktab;
+    }
     ix.idxchain = LJ_MAX_IDXCHAIN;
     rc = lj_record_idx(J, &ix);
     break;


### PR DESCRIPTION
This lets different functions in the same trace share global lookup code. Example code:

```lua
function g(n)
	return math.floor(n)
end

function f(n)
	return (g(math.ceil(n - 1.5)))
end

function bench()
	local s = 0
	local before = os.clock()
	for i = 1, 100000000 do
		s = s + f(i)
	end
	local after = os.clock()
	print(after - before, s)
end
jit.off(bench)

bench()
```

Without the patch, the benchmark time is about 3.6 on my computer. With the patch, the benchmark time is about 2.9.