### PR TITLE
Allow building with Clang on PPC

### DIFF
--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -465,6 +465,10 @@
 #error "Need at least GCC 4.8 or newer"
 #endif
 #endif
+#elif LJ_TARGET_PPC
+#if ((__clang_major__ < 8) || ((__clang_major__ == 0) && __clang_minor__ < 0))
+#error "Need at least Clang 8.0 or newer"
+#endif
 #elif !LJ_TARGET_PS3
 #if (__GNUC__ < 4) || ((__GNUC__ == 4) && __GNUC_MINOR__ < 3)
 #error "Need at least GCC 4.3 or newer"


### PR DESCRIPTION
Clang pretends to be GCC 4.2 and fails with:
`lj_arch.h:503:2: error: "Need at least GCC 4.3 or newer" #error "Need at least GCC 4.3 or newer"`

Clang 8.0.0 was the first to have proper PPC support. I'm testing here on 13.0.0 on FreeBSD 13.1-RELEASE.