### PR TITLE
Use pre-existing ERRNO_SAVE / ERRNO_RESTORE if defined

### DIFF
--- a/src/lj_dispatch.h
+++ b/src/lj_dispatch.h
@@ -144,6 +144,7 @@ LJ_FUNCA void LJ_FASTCALL lj_dispatch_stitch(jit_State *J, const BCIns *pc);
 LJ_FUNCA void LJ_FASTCALL lj_dispatch_profile(lua_State *L, const BCIns *pc);
 #endif
 
+#if !defined(ERRNO_SAVE) && !defined(ERRNO_RESTORE)
 #if LJ_HASFFI && !defined(_BUILDVM_H)
 /* Save/restore errno and GetLastError() around hooks, exits and recording. */
 #include <errno.h>
@@ -159,6 +160,7 @@ LJ_FUNCA void LJ_FASTCALL lj_dispatch_profile(lua_State *L, const BCIns *pc);
 #else
 #define ERRNO_SAVE
 #define ERRNO_RESTORE
+#endif
 #endif
 
 #endif


### PR DESCRIPTION
If `ERRNO_SAVE` and `ERRNO_RESTORE` are already pre-defined, use them instead of redefining them.