### PR TITLE
Add an option to disable clib support in ffi

### DIFF
--- a/src/lj_clib.c
+++ b/src/lj_clib.c
@@ -5,7 +5,7 @@
 
 #include "lj_obj.h"
 
-#if LJ_HASFFI
+#if LJ_HASFFI && !defined(LUAJIT_DISABLE_CLIB)
 
 #include "lj_gc.h"
 #include "lj_err.h"


### PR DESCRIPTION
Add a compile-time option to disable clib support in FFI. This disables dynamic loading of libraries from FFI as well as the built-in `.C` library. Intended for use in restricted environments either for security reasons or for lack of a dynamic loader