### PR TITLE
Add options to disable the io and os modules

### DIFF
--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -77,8 +77,10 @@ LUALIB_API const char *(luaL_findtable) (lua_State *L, int idx,
                                          const char *fname, int szhint);
 
 /* From Lua 5.2. */
+#if !defined(LUAJIT_DISABLE_MODULE_IO) || !defined(LUAJIT_DISABLE_MODULE_OS)
 LUALIB_API int luaL_fileresult(lua_State *L, int stat, const char *fname);
 LUALIB_API int luaL_execresult(lua_State *L, int stat);
+#endif
 LUALIB_API int (luaL_loadfilex) (lua_State *L, const char *filename,
 				 const char *mode);
 LUALIB_API int (luaL_loadbufferx) (lua_State *L, const char *buff, size_t sz,

--- a/src/lib_aux.c
+++ b/src/lib_aux.c
@@ -26,6 +26,8 @@
 #include <sys/wait.h>
 #endif
 
+#if !defined(LUAJIT_DISABLE_MODULE_IO) || !defined(LUAJIT_DISABLE_MODULE_OS)
+
 /* -- I/O error handling -------------------------------------------------- */
 
 LUALIB_API int luaL_fileresult(lua_State *L, int stat, const char *fname)
@@ -75,6 +77,8 @@ LUALIB_API int luaL_execresult(lua_State *L, int stat)
   }
   return luaL_fileresult(L, 0, NULL);
 }
+
+#endif
 
 /* -- Module registration ------------------------------------------------- */
 

--- a/src/lib_init.c
+++ b/src/lib_init.c
@@ -19,8 +19,12 @@ static const luaL_Reg lj_lib_load[] = {
   { "",			luaopen_base },
   { LUA_LOADLIBNAME,	luaopen_package },
   { LUA_TABLIBNAME,	luaopen_table },
+#ifndef LUAJIT_DISABLE_MODULE_IO
   { LUA_IOLIBNAME,	luaopen_io },
+#endif
+#ifndef LUAJIT_DISABLE_MODULE_OS
   { LUA_OSLIBNAME,	luaopen_os },
+#endif
   { LUA_STRLIBNAME,	luaopen_string },
   { LUA_MATHLIBNAME,	luaopen_math },
   { LUA_DBLIBNAME,	luaopen_debug },

--- a/src/lib_io.c
+++ b/src/lib_io.c
@@ -16,6 +16,8 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#ifndef LUAJIT_DISABLE_MODULE_IO
+
 #include "lj_obj.h"
 #include "lj_gc.h"
 #include "lj_err.h"
@@ -549,3 +551,4 @@ LUALIB_API int luaopen_io(lua_State *L)
   return 1;
 }
 
+#endif

--- a/src/lib_os.c
+++ b/src/lib_os.c
@@ -16,6 +16,8 @@
 #include "lauxlib.h"
 #include "lualib.h"
 
+#ifndef LUAJIT_DISABLE_MODULE_OS
+
 #include "lj_obj.h"
 #include "lj_gc.h"
 #include "lj_err.h"
@@ -290,3 +292,4 @@ LUALIB_API int luaopen_os(lua_State *L)
   return 1;
 }
 
+#endif

--- a/src/lualib.h
+++ b/src/lualib.h
@@ -26,8 +26,12 @@ LUALIB_API int luaopen_base(lua_State *L);
 LUALIB_API int luaopen_math(lua_State *L);
 LUALIB_API int luaopen_string(lua_State *L);
 LUALIB_API int luaopen_table(lua_State *L);
+#ifndef LUAJIT_DISABLE_MODULE_IO
 LUALIB_API int luaopen_io(lua_State *L);
+#endif
+#ifndef LUAJIT_DISABLE_MODULE_OS
 LUALIB_API int luaopen_os(lua_State *L);
+#endif
 LUALIB_API int luaopen_package(lua_State *L);
 LUALIB_API int luaopen_debug(lua_State *L);
 LUALIB_API int luaopen_bit(lua_State *L);


### PR DESCRIPTION
Add compile-time options to disable inclusion of the `io` and `os` Lua modules. Intended for use in restricted environments where file I/O from Lua scripts is not desirable