### PR TITLE
Add an option to disable loadfile APIs

### DIFF
--- a/src/host/buildvm_lib.c
+++ b/src/host/buildvm_lib.c
@@ -387,6 +387,8 @@ void emit_lib(BuildCtx *ctx)
 	  ok = LJ_HASFFI;
 	else if (!strcmp(buf, "#if LJ_HASBUFFER\n"))
 	  ok = LJ_HASBUFFER;
+        else if (!strcmp(buf, "#if LJ_HASLOADFILE\n"))
+          ok = LJ_HASLOADFILE;
 	if (!ok) {
 	  int lvl = 1;
 	  while (fgets(buf, sizeof(buf), fp) != NULL) {

--- a/src/lauxlib.h
+++ b/src/lauxlib.h
@@ -62,7 +62,9 @@ LUALIB_API int (luaL_checkoption) (lua_State *L, int narg, const char *def,
 LUALIB_API int (luaL_ref) (lua_State *L, int t);
 LUALIB_API void (luaL_unref) (lua_State *L, int t, int ref);
 
+#ifndef LUAJIT_DISABLE_LOADFILE
 LUALIB_API int (luaL_loadfile) (lua_State *L, const char *filename);
+#endif
 LUALIB_API int (luaL_loadbuffer) (lua_State *L, const char *buff, size_t sz,
                                   const char *name);
 LUALIB_API int (luaL_loadstring) (lua_State *L, const char *s);
@@ -79,8 +81,10 @@ LUALIB_API const char *(luaL_findtable) (lua_State *L, int idx,
 /* From Lua 5.2. */
 LUALIB_API int luaL_fileresult(lua_State *L, int stat, const char *fname);
 LUALIB_API int luaL_execresult(lua_State *L, int stat);
+#ifndef LUAJIT_DISABLE_LOADFILE
 LUALIB_API int (luaL_loadfilex) (lua_State *L, const char *filename,
 				 const char *mode);
+#endif
 LUALIB_API int (luaL_loadbufferx) (lua_State *L, const char *buff, size_t sz,
 				   const char *name, const char *mode);
 LUALIB_API void luaL_traceback (lua_State *L, lua_State *L1, const char *msg,

--- a/src/lib_base.c
+++ b/src/lib_base.c
@@ -373,6 +373,8 @@ static int load_aux(lua_State *L, int status, int envarg)
   }
 }
 
+#if LJ_HASLOADFILE
+
 LJLIB_CF(loadfile)
 {
   GCstr *fname = lj_lib_optstr(L, 1);
@@ -383,6 +385,8 @@ LJLIB_CF(loadfile)
 			  mode ? strdata(mode) : NULL);
   return load_aux(L, status, 3);
 }
+
+#endif
 
 static const char *reader_func(lua_State *L, void *ud, size_t *size)
 {
@@ -439,6 +443,8 @@ LJLIB_CF(loadstring)
   return lj_cf_load(L);
 }
 
+#if LJ_HASLOADFILE
+
 LJLIB_CF(dofile)
 {
   GCstr *fname = lj_lib_optstr(L, 1);
@@ -449,6 +455,8 @@ LJLIB_CF(dofile)
   lua_call(L, 0, LUA_MULTRET);
   return (int)(L->top - L->base) - 1;
 }
+
+#endif
 
 /* -- Base library: GC control -------------------------------------------- */
 

--- a/src/lj_arch.h
+++ b/src/lj_arch.h
@@ -594,6 +594,12 @@
 #define LJ_HASPROFILE		0
 #endif
 
+#if defined(LUAJIT_DISABLE_LOADFILE)
+#define LJ_HASLOADFILE          0
+#else
+#define LJ_HASLOADFILE          1
+#endif
+
 #ifndef LJ_ARCH_HASFPU
 #define LJ_ARCH_HASFPU		1
 #endif

--- a/src/lj_load.c
+++ b/src/lj_load.c
@@ -67,6 +67,8 @@ LUA_API int lua_load(lua_State *L, lua_Reader reader, void *data,
   return lua_loadx(L, reader, data, chunkname, NULL);
 }
 
+#if LJ_HASLOADFILE
+
 typedef struct FileReaderCtx {
   FILE *fp;
   char buf[LUAL_BUFFERSIZE];
@@ -118,6 +120,8 @@ LUALIB_API int luaL_loadfile(lua_State *L, const char *filename)
 {
   return luaL_loadfilex(L, filename, NULL);
 }
+
+#endif
 
 typedef struct StringReaderCtx {
   const char *str;


### PR DESCRIPTION
Add a compile-time option to disable the `luaL_loadfile` and `luaL_loadfilex` APIs. This also, by necessity, removes the `loadfile` and `dofile` functions from the `base` Lua module. Intended for use in restricted environments that do not want filesystem access exported to Lua