### PR TITLE
Fix -Warray-bounds warnings on gcc

### DIFF
--- a/dynasm/dasm_arm.h
+++ b/dynasm/dasm_arm.h
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#ifdef _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
 #define DASM_ARCH		"arm"
 
 #ifndef DASM_EXTERN
@@ -123,7 +137,7 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
-  D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+  D->globals = (void **)((uintptr_t)gl - 10);  /* Negative bias to compensate for locals. */
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 

--- a/dynasm/dasm_arm64.h
+++ b/dynasm/dasm_arm64.h
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#ifdef _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
 #define DASM_ARCH		"arm64"
 
 #ifndef DASM_EXTERN
@@ -125,7 +139,7 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
-  D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+  D->globals = (void **)((uintptr_t)gl - 10);  /* Negative bias to compensate for locals. */
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 

--- a/dynasm/dasm_mips.h
+++ b/dynasm/dasm_mips.h
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#ifdef _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
 #define DASM_ARCH		"mips"
 
 #ifndef DASM_EXTERN
@@ -122,7 +136,7 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
-  D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+  D->globals = (void **)((uintptr_t)gl - 10);  /* Negative bias to compensate for locals. */
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 

--- a/dynasm/dasm_ppc.h
+++ b/dynasm/dasm_ppc.h
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#ifdef _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
 #define DASM_ARCH		"ppc"
 
 #ifndef DASM_EXTERN
@@ -122,7 +136,7 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
-  D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+  D->globals = (void **)((uintptr_t)gl - 10);  /* Negative bias to compensate for locals. */
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 

--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -9,6 +9,20 @@
 #include <string.h>
 #include <stdlib.h>
 
+#if defined(_MSC_VER) && (_MSC_VER < 1700)
+/* Old MSVC is stuck in the last century and doesn't have C99's stdint.h. */
+#ifdef _WIN64
+typedef unsigned __int64 uintptr_t;
+#else
+typedef unsigned __int32 uintptr_t;
+#endif
+#elif defined(__symbian__)
+/* Cough. */
+typedef unsigned int uintptr_t;
+#else
+#include <stdint.h>
+#endif
+
 #define DASM_ARCH		"x86"
 
 #ifndef DASM_EXTERN
@@ -121,7 +135,7 @@ void dasm_free(Dst_DECL)
 void dasm_setupglobal(Dst_DECL, void **gl, unsigned int maxgl)
 {
   dasm_State *D = Dst_REF;
-  D->globals = gl - 10;  /* Negative bias to compensate for locals. */
+  D->globals = (void **)((uintptr_t)gl - 10);  /* Negative bias to compensate for locals. */
   DASM_M_GROW(Dst, int, D->lglabels, D->lgsize, (10+maxgl)*sizeof(int));
 }
 


### PR DESCRIPTION
With optimizations/inlining enabled GCC complains about `gl - 10` resulting in a pointer to invalid memory when `Dst` is an array type rather than a pointer.

I wasn't sure if this is the right branch, let me know if I need to rebase/retarget.