### PR TITLE
Fix Parameter Escape "%1"

### DIFF
--- a/src/msvcbuild.bat
+++ b/src/msvcbuild.bat
@@ -43,7 +43,7 @@ if exist minilua.exe.manifest^
 @set LJARCH=x86
 @set LJCOMPILE=%LJCOMPILE% /arch:SSE2
 :X64
-@if "%1" neq "nogc64" goto :GC64
+@if "%~1" neq "nogc64" goto :GC64
 @shift
 @set DASC=vm_x86.dasc
 @set LJCOMPILE=%LJCOMPILE% /DLUAJIT_DISABLE_GC64


### PR DESCRIPTION
Hello, I am a maintainer of vcpkg.
Recently, we received an issue about a path specific character parsing error.

If the value of parameter `'%1'` contains spaces or other special characters, quotation marks are required when referencing it.

However, in this command line statement, this parameter is referenced without quotation marks, which may result in its value being interpreted as multiple parameters rather than one parameter.
```
@if "%1" neq "nogc64" goto :GC64
```
`"%~1"` is a special syntax in the Windows command extension, which means removing quotation marks from the parameter `% 1` before referencing it. 

This can solve the problem of quotation marks in parameters, while still retaining spaces and other special characters in parameter values.

Releated issue: https://github.com/microsoft/vcpkg/issues/30524
@MikePall 