### PR TITLE
Fix warning on some compilers for size_t to int truncation

### DIFF
--- a/src/host/buildvm_lib.c
+++ b/src/host/buildvm_lib.c
@@ -378,7 +378,7 @@ void emit_lib(BuildCtx *ctx)
       char *p;
       /* Simplistic pre-processor. Only handles top-level #if/#endif. */
       if (buf[0] == '#' && buf[1] == 'i' && buf[2] == 'f') {
-	int ok = 1, len = strlen(buf);
+	int ok = 1, len = (int)strlen(buf);
 	if (buf[len-1] == '\n') {
 	  buf[len-1] = 0;
 	  if (buf[len-2] == '\r') {


### PR DESCRIPTION
Visual Studio warns over this with some warning levels.