### PR TITLE
Ensure proper JIT execution context on C callbacks

### DIFF
--- a/src/lj_ccallback.c
+++ b/src/lj_ccallback.c
@@ -681,6 +681,7 @@ lua_State * LJ_FASTCALL lj_ccallback_enter(CTState *cts, void *cf)
   lua_State *L = cts->L;
   global_State *g = cts->g;
   lj_assertG(L != NULL, "uninitialized cts->L in callback");
+  setgcref(g->cur_L, obj2gco(L));
   if (tvref(g->jit_base)) {
     setstrV(L, L->top++, lj_err_str(L, LJ_ERR_FFI_BADCBACK));
     if (g->panic) g->panic(L);


### PR DESCRIPTION
This fixes a rare but obnoxious crash.

It is difficult to come up with a reproduction case as a result, but here's the gist of what's going on:

- Have some Lua code using FFI C callbacks
- Have Lua threads
- Have the JIT turned on

With this combination of things, we may end up with our `cur_L` global pointing to a different thread that doesn't have a proper `cframe` setup. So what may happen sometimes is:

- `lj_ccallback_enter` gets called
  - it sets up `L->cframe` on its own local CTState
- `vm_exit_handler` gets called
  - it sets `J->L` with a `cur_L` with a *different* `lua_State` that has no cframe
- `lj_trace_exit` gets called
  - It ends up with a nullptr `cf` and segfaults on the `setcframe_pc` here: https://github.com/LuaJIT/LuaJIT/blob/51fb2f2c3af778f03258fccee9092401ee4a0215/src/lj_trace.c#L907-L908
