### PR TITLE
Arm64: Fix LDP instruction fuse when offset is negative.

### DIFF
--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -143,7 +143,7 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
       goto nopair;
     }
     if (ofsm >= (int)((unsigned int)-64<<sc) && ofsm <= (63<<sc)) {
-      *as->mcp = aip | A64F_N(rn) | ((ofsm >> sc) << 15) |
+      *as->mcp = aip | A64F_N(rn) | (((ofsm >> sc)&0x7f) << 15) |
 	(ai ^ ((ai == A64I_LDRx || ai == A64I_STRx) ? 0x50000000 : 0x90000000));
       return;
     }


### PR DESCRIPTION
LDP fuse can produce ill instruction. Here is the code to reproduce the error on Arm64:

```
local ffi               = require "ffi"

ffi.cdef[[
  typedef struct data {
    int32_t    m1;
    int32_t    m2;
  } data;
]]
local const_data_ptr = ffi.typeof("const data*")
local out_data = {}
local metrics = ffi.new("data[10]")
local data = ffi.cast(const_data_ptr, metrics)

for i = 1, 10 do
    local c = data[i - 1]
    local m1 = c.m1
    local m2 = c.m2

    out_data[i] = {
      m1,
      m2,
    }
end

print(out_data)
```


run: `luajit -Ohotloop=1 test.lua` will run into:
``` sh
Illegal instruction (core dumped)
```

And here is the dumped trace and note that there is a wrong instruction `0xffff6f7a` in the machine code:
```
---- TRACE 1 start test.lua:14
0022  SUBVN    9   8   0  ; 1       (test.lua:15)
0023  TGETV    9   4   9       (test.lua:15)
0000  . . FUNCC               ; ffi.meta.__index
0024  TGETS   10   9   9  ; "m1"       (test.lua:16)
0000  . . FUNCC               ; ffi.meta.__index
0025  TGETS   11   9  10  ; "m2"       (test.lua:17)
0000  . . FUNCC               ; ffi.meta.__index
0026  TNEW    12   3       (test.lua:19)
0027  TSETB   10  12   1       (test.lua:20)
0028  TSETB   11  12   2       (test.lua:21)
0029  TSETV   12   2   8       (test.lua:22)
0030  FORL     5 => 0022       (test.lua:14)
---- TRACE 1 IR
0001    int SLOAD  #7    I
0003 >  cdt SLOAD  #6    T
0004    u16 FLOAD  0003  cdata.ctypeid
0005 >  int EQ     0004  +102
0006    p64 FLOAD  0003  cdata.ptr
0007    i64 CONV   0001  i64.int
0009    i64 BSHL   0007  +3  
0010    p64 ADD    0009  0006
0011    p64 ADD    0010  -8  
0013    int XLOAD  0011  
0014    p64 ADD    0010  -4  
0015    int XLOAD  0014  
0016 >  tab TNEW   #3    #0  
0017    p64 FLOAD  0016  tab.array
0018    p64 AREF   0017  +1  
0019    int ASTORE 0018  0013
0020    p64 AREF   0017  +2  
0021    int ASTORE 0020  0015
0022 >  tab SLOAD  #4    T
0023    int FLOAD  0022  tab.asize
0024 >  int ABC    0023  0001
0025    p64 FLOAD  0022  tab.array
0026    p64 AREF   0025  0001
0027    tab FLOAD  0022  tab.meta
0028 >  tab EQ     0027  NULL
0029    tab ASTORE 0026  0016
0030    nil TBAR   0022
0031  + int ADD    0001  +1  
0032 >  int LE     0031  +10 
0033 ------ LOOP ------------
0034    i64 CONV   0031  i64.int
0035    i64 BSHL   0034  +3  
0036    p64 ADD    0035  0006
0037    p64 ADD    0036  -8  
0038    int XLOAD  0037  
0039    p64 ADD    0036  -4  
0040    int XLOAD  0039  
0041 >  tab TNEW   #3    #0  
0042    p64 FLOAD  0041  tab.array
0043    p64 AREF   0042  +1  
0044    int ASTORE 0043  0038
0045    p64 AREF   0042  +2  
0046    int ASTORE 0045  0040
0047 >  int ABC    0023  0031
0048    p64 AREF   0025  0031
0049    tab ASTORE 0048  0041
0050    nil TBAR   0022
0051  + int ADD    0031  +1  
0052 >  int LE     0051  +10 
0053    int PHI    0031  0051
---- TRACE 1 mcode 388
020ffe58  sub   sp, sp, #16
020ffe5c  str   x19, [sp, #8]
020ffe60  mov   x24, #65529, lsl #48
020ffe64  mov   x20, #65524
020ffe68  movk  x20, #65535, lsl #16
020ffe6c  ldp   x30, x1, [x22, #32]
020ffe70  cmp   x30, x1
020ffe74  bls   0x020ffe8c
020ffe78  mov   x1, #1
020ffe7c  mov   x0, x22
020ffe80  bl    0x0043ec00	->lj_gc_step_jit
020ffe84  orr   x30, x30, x30
020ffe88  cbnz  w0, 0x020fffe8	->0
020ffe8c  ldr   x1, [sp, #8]
020ffe90  ldr   x0, [x22, #368]
020ffe94  ldr   w28, [x1, #40]
020ffe98  ldr   x2, [x1, #32]
020ffe9c  asr   x27, x2, #47
020ffea0  cmn   x27, #11
020ffea4  bne   0x020fffe8	->0
020ffea8  and   x2, x2, #0x7fffffffffff
020ffeac  mov   x1, #3
020ffeb0  ldrh  w3, [x2, #10]
020ffeb4  cmp   w3, #102
020ffeb8  bne   0x020fffe8	->0
020ffebc  ldr   x25, [x2, #16]
020ffec0  mov   x2, x28
020ffec4  add   x2, x25, x2, lsl #3
020ffec8  ldur  w3, [x2, #-8]
020ffecc  str   w3, [sp, #20]
020ffed0  ldur  w2, [x2, #-4]
020ffed4  str   w2, [sp, #16]
020ffed8  bl    0x0044042c	->lj_tab_new1
020ffedc  ldp   w2, w3, [sp, #16]
020ffee0  ldr   x1, [sp, #8]
020ffee4  add   x30, x24, w3, uxtw
020ffee8  str   x30, [x0, #72]
020ffeec  add   x30, x24, w2, uxtw
020ffef0  str   x30, [x0, #80]
020ffef4  ldr   x19, [x1, #16]
020ffef8  asr   x27, x19, #47
020ffefc  cmn   x27, #12
020fff00  bne   0x020fffec	->1
020fff04  and   x19, x19, #0x7fffffffffff
020fff08  ldr   w23, [x19, #48]
020fff0c  cmp   w23, w28
020fff10  bls   0x020fffec	->1
020fff14  ldr   x21, [x19, #16]
020fff18  ldr   x1, [x19, #32]
020fff1c  cbnz  x1, 0x020fffec	->1
020fff20  add   x30, x0, x20, lsl #47
020fff24  str   x30, [x21, w28, uxtw #3]
020fff28  ldrb  w30, [x19, #8]
020fff2c  tst   w30, #0x4
020fff30  beq   0x020fff48
020fff34  ldr   x27, [x22, #64]
020fff38  and   w30, w30, #0xfffffffb
020fff3c  str   x19, [x22, #64]
020fff40  strb  w30, [x19, #8]
020fff44  str   x27, [x19, #24]
020fff48  add   w28, w28, #1
020fff4c  cmp   w28, #10
020fff50  bgt   0x020ffff0	->2
->LOOP:
020fff54  ldp   x30, x1, [x22, #32]
020fff58  cmp   x30, x1
020fff5c  bls   0x020fff74
020fff60  mov   x1, #1
020fff64  mov   x0, x22
020fff68  bl    0x0043ec00	->lj_gc_step_jit
020fff6c  orr   x30, x30, x30
020fff70  cbnz  w0, 0x020ffff4	->3
020fff74  mov   x1, #3
020fff78  ldr   x0, [x22, #368]
020fff7c  mov   x27, x28
020fff80  add   x27, x25, x27, lsl #3
020fff84  .long 0xffff6f7a
020fff88  bl    0x0044042c	->lj_tab_new1
020fff8c  add   x30, x24, w26, uxtw
020fff90  str   x30, [x0, #72]
020fff94  add   x30, x24, w27, uxtw
020fff98  str   x30, [x0, #80]
020fff9c  cmp   w23, w28
020fffa0  bls   0x020ffff8	->4
020fffa4  add   x30, x0, x20, lsl #47
020fffa8  str   x30, [x21, w28, uxtw #3]
020fffac  ldrb  w30, [x19, #8]
020fffb0  tst   w30, #0x4
020fffb4  beq   0x020fffcc
020fffb8  ldr   x27, [x22, #64]
020fffbc  and   w30, w30, #0xfffffffb
020fffc0  str   x19, [x22, #64]
020fffc4  strb  w30, [x19, #8]
020fffc8  str   x27, [x19, #24]
020fffcc  add   w28, w28, #1
020fffd0  cmp   w28, #10
020fffd4  ble   0x020fff54	->LOOP
020fffd8  b     0x020ffffc	->5
---- TRACE 1 stop -> loop
```

After applying this fix, it runs without error and the dumped machine code is like:
```
102ecfd40  ldr   x0, [x22, #368]
102ecfd44  mov   x27, x28
102ecfd48  add   x27, x25, x27, lsl #3
102ecfd4c  ldp   w26, w27, [x27, #-8] -- fixed.
102ecfd50  bl    0x0082fce0	->lj_tab_new1
102ecfd54  add   x30, x24, w26, uxtw
```