### PR TITLE
DynASM: Fix crash in dasm_encode() when some section is empty

### DIFF
--- a/dynasm/dasm_arm.h
+++ b/dynasm/dasm_arm.h
@@ -141,6 +141,7 @@ void dasm_setup(Dst_DECL, const void *actionlist)
   memset((void *)D->lglabels, 0, D->lgsize);
   if (D->pclabels) memset((void *)D->pclabels, 0, D->pcsize);
   for (i = 0; i < D->maxsection; i++) {
+    D->sections[i].rbuf = D->sections[i].buf - DASM_SEC2POS(i);
     D->sections[i].pos = DASM_SEC2POS(i);
     D->sections[i].ofs = 0;
   }

--- a/dynasm/dasm_arm64.h
+++ b/dynasm/dasm_arm64.h
@@ -143,6 +143,7 @@ void dasm_setup(Dst_DECL, const void *actionlist)
   memset((void *)D->lglabels, 0, D->lgsize);
   if (D->pclabels) memset((void *)D->pclabels, 0, D->pcsize);
   for (i = 0; i < D->maxsection; i++) {
+    D->sections[i].rbuf = D->sections[i].buf - DASM_SEC2POS(i);
     D->sections[i].pos = DASM_SEC2POS(i);
     D->sections[i].ofs = 0;
   }

--- a/dynasm/dasm_mips.h
+++ b/dynasm/dasm_mips.h
@@ -140,6 +140,7 @@ void dasm_setup(Dst_DECL, const void *actionlist)
   memset((void *)D->lglabels, 0, D->lgsize);
   if (D->pclabels) memset((void *)D->pclabels, 0, D->pcsize);
   for (i = 0; i < D->maxsection; i++) {
+    D->sections[i].rbuf = D->sections[i].buf - DASM_SEC2POS(i);
     D->sections[i].pos = DASM_SEC2POS(i);
     D->sections[i].ofs = 0;
   }

--- a/dynasm/dasm_ppc.h
+++ b/dynasm/dasm_ppc.h
@@ -140,6 +140,7 @@ void dasm_setup(Dst_DECL, const void *actionlist)
   memset((void *)D->lglabels, 0, D->lgsize);
   if (D->pclabels) memset((void *)D->pclabels, 0, D->pcsize);
   for (i = 0; i < D->maxsection; i++) {
+    D->sections[i].rbuf = D->sections[i].buf - DASM_SEC2POS(i);
     D->sections[i].pos = DASM_SEC2POS(i);
     D->sections[i].ofs = 0;
   }

--- a/dynasm/dasm_x86.h
+++ b/dynasm/dasm_x86.h
@@ -139,6 +139,7 @@ void dasm_setup(Dst_DECL, const void *actionlist)
   memset((void *)D->lglabels, 0, D->lgsize);
   if (D->pclabels) memset((void *)D->pclabels, 0, D->pcsize);
   for (i = 0; i < D->maxsection; i++) {
+    D->sections[i].rbuf = D->sections[i].buf - DASM_SEC2POS(i);
     D->sections[i].pos = DASM_SEC2POS(i);
     D->sections[i].ofs = 0;
   }


### PR DESCRIPTION
Fixes GH #1041