### PR TITLE
Updated outdated url in lj_jit.h

### DIFF
--- a/src/lj_jit.h
+++ b/src/lj_jit.h
@@ -105,7 +105,7 @@
 /* -- JIT engine parameters ----------------------------------------------- */
 
 #if LJ_TARGET_WINDOWS || LJ_64
-/* See: http://blogs.msdn.com/oldnewthing/archive/2003/10/08/55239.aspx */
+/* See: https://devblogs.microsoft.com/oldnewthing/20031008-00/?p=42223 */
 #define JIT_P_sizemcode_DEFAULT		64
 #else
 /* Could go as low as 4K, but the mmap() overhead would be rather high. */


### PR DESCRIPTION
Updated url to Raymond Chen's "Why is address space allocation granularity 64KB?" post on The Old New Thing.