### PR TITLE
let makefile work for mingw running on windows cmd

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -474,8 +474,13 @@ endif
 DASM_FLAGS= $(DASM_XFLAGS) $(DASM_AFLAGS)
 DASM_DASC= vm_$(DASM_ARCH).dasc
 
-GIT= git
-GIT_RELVER= [ -e ../.git ] && $(GIT) show -s --format=%ct >luajit_relver.txt 2>/dev/null || cat ../.relver >luajit_relver.txt 2>/dev/null || :
+GIT= 
+ifeq (,$(HOST_MSYS))
+    GIT_RELVER= if exist ..\.git ( git show -s --format=%%ct >luajit_relver.txt ) else ( type ..\.relver >luajit_relver.txt )
+else
+    GIT_RELVER= [ -e ../.git ] && $(GIT) show -s --format=%ct >luajit_relver.txt 2>/dev/null || cat ../.relver >luajit_relver.txt 2>/dev/null || :
+endif
+
 GIT_DEP= $(wildcard ../.git/HEAD ../.git/refs/heads/*)
 
 BUILDVM_O= host/buildvm.o host/buildvm_asm.o host/buildvm_peobj.o \

--- a/src/Makefile
+++ b/src/Makefile
@@ -476,7 +476,7 @@ DASM_DASC= vm_$(DASM_ARCH).dasc
 
 GIT= 
 ifeq (,$(HOST_MSYS))
-    GIT_RELVER= if exist ..\.git ( git show -s --format=%%ct >luajit_relver.txt ) else ( type ..\.relver >luajit_relver.txt )
+    GIT_RELVER= if exist ..\.git\ ( git show -s --format=%%ct >luajit_relver.txt ) else ( type ..\.relver >luajit_relver.txt )
 else
     GIT_RELVER= [ -e ../.git ] && $(GIT) show -s --format=%ct >luajit_relver.txt 2>/dev/null || cat ../.relver >luajit_relver.txt 2>/dev/null || :
 endif


### PR DESCRIPTION
This is the solution founded for letting makefile work for mingw running on windows cmd

New commit added for checking .git is a folder and not a file (happens when LuaJIT repo is a submodule of another repo)
msvcbuild.bat should incorporate this change also. (I can add that in this PR if you wish)