### PR TITLE
Allow to use a commit hash for .relver

### DIFF
--- a/src/host/genversion.lua
+++ b/src/host/genversion.lua
@@ -29,7 +29,7 @@ local function file_write_mod(file, data)
 end
 
 local text = file_read(FILE_ROLLING_H)
-local relver = file_read(FILE_RELVER_TXT):match("(%d+)")
+local relver = file_read(FILE_RELVER_TXT):match("(%w+)")
 
 if relver then
   text = text:gsub("ROLLING", relver)


### PR DESCRIPTION
Based on the answer made in https://github.com/LuaJIT/LuaJIT/issues/1053#issuecomment-1689000029

Would it be accepted to use the commit hash as the rolling release version identifier. If so this change allows to set the commit hash inside the `.relver` file and use this.

One usecase would be to make it simpler to package it instead of relying on the usage of `git` being available. 