### PR TITLE
ARM64: Fix LDP/STP fusion error.

### DIFF
--- a/src/lj_emit_arm64.h
+++ b/src/lj_emit_arm64.h
@@ -133,10 +133,12 @@ static void emit_lso(ASMState *as, A64Ins ai, Reg rd, Reg rn, int64_t ofs)
     int ofsm = ofs - (1<<sc), ofsp = ofs + (1<<sc);
     A64Ins aip;
     if (prev == (ai | A64F_N(rn) | A64F_U12(ofsm>>sc)) ||
-	prev == ((ai^A64I_LS_U) | A64F_N(rn) | A64F_S9(ofsm&0x1ff))) {
+	(emit_checkofs(A64I_LS_U, ofsm) == -1 &&
+         prev == ((ai^A64I_LS_U) | A64F_N(rn) | A64F_S9(ofsm&0x1ff)))) {
       aip = (A64F_A(rd) | A64F_D(*as->mcp & 31));
     } else if (prev == (ai | A64F_N(rn) | A64F_U12(ofsp>>sc)) ||
-	       prev == ((ai^A64I_LS_U) | A64F_N(rn) | A64F_S9(ofsp&0x1ff))) {
+	       (emit_checkofs(A64I_LS_U, ofsp) == -1 &&
+                prev == ((ai^A64I_LS_U) | A64F_N(rn) | A64F_S9(ofsp&0x1ff)))) {
       aip = (A64F_D(rd) | A64F_A(*as->mcp & 31));
       ofsm = ofs;
     } else {


### PR DESCRIPTION
The current fusion will mistakenly fuse case like:
```
str x30, [x19, #488]
stur x0, [x19, -16]
```

Here is the test case:
```
local ffi = require("ffi")
local buf = require("string.buffer").new()

-- failure case
for i = 1, 60 do
  local ptr = buf:reset():reserve(520)
  local ptr2 = ptr + 16
  ffi.fill(ptr, 520, 99)
  print(ptr)
  -- the next load: 488+8 in imm12 is 0001 1111 0000, the lower 9 bit is the same as -16 in signed imm9.
  ffi.cast("int64_t*", ptr2 + 488)[0] = i
  -- -16 in signed imm9 1 1111 0000
  ffi.cast("int64_t*", ptr2 - 16)[0] = i 
  buf:commit(520)
end
local content = table.concat({tostring(buf):byte(1,520)}, ",")
assert(content == "60,0,0,0,0,0,0,0,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,60,0,0,0,0,0,0,0,99,99,99,99,99,99,99,99",content)
```

Here is the related Trace dump. 
before applying this fix:
```
---- TRACE 2 start 1/stitch stp_failure_test_case.lua:9
0029  TGETS    8   0   8  ; "cast"       (stp_failure_test_case.lua:11)
0030  KSTR    10   9      ; "int64_t*"       (stp_failure_test_case.lua:11)
0031  ADDVN   11   7   1  ; 488       (stp_failure_test_case.lua:11)
0000  . . FUNCC               ; ffi.meta.__add
0032  CALL     8   2   3       (stp_failure_test_case.lua:11)
0000  . FUNCC               ; ffi.cast
0033  TSETB    5   8   0       (stp_failure_test_case.lua:11)
0000  . . FUNCC               ; ffi.meta.__newindex
0034  TGETS    8   0   8  ; "cast"       (stp_failure_test_case.lua:13)
0035  KSTR    10   9      ; "int64_t*"       (stp_failure_test_case.lua:13)
0036  SUBVN   11   7   0  ; 16       (stp_failure_test_case.lua:13)
0000  . . FUNCC               ; ffi.meta.__sub
0037  CALL     8   2   3       (stp_failure_test_case.lua:13)
0000  . FUNCC               ; ffi.cast
0038  TSETB    5   8   0       (stp_failure_test_case.lua:13)
0000  . . FUNCC               ; ffi.meta.__newindex
0039  MOV     10   1       (stp_failure_test_case.lua:14)
0040  TGETS    8   1  10  ; "commit"       (stp_failure_test_case.lua:14)
0041  KSHORT  11 520       (stp_failure_test_case.lua:14)
0042  CALL     8   1   3       (stp_failure_test_case.lua:14)
0000  . FUNCC               ; buffer.method.commit
0043  JFORL    2   1       (stp_failure_test_case.lua:5)
---- TRACE 2 IR
0001 >  tab SLOAD  #2    T
0002    int FLOAD  0001  tab.hmask
0003 >  int EQ     0002  +31 
0004    p64 FLOAD  0001  tab.node
0005 >  p64 HREFK  0004  "cast" @6
0006 >  fun HLOAD  0005
0007 >  cdt SLOAD  #9    T
0008    u16 FLOAD  0007  cdata.ctypeid
0009 >  int EQ     0008  +20 
0010    p64 FLOAD  0007  cdata.ptr
0011    p64 ADD    0010  +488
0012 }  cdt CNEWI  +20   0011
0013 >  fun EQ     0006  ffi.cast
0014 }  cdt CNEWI  +97   0011
0015 >  int SLOAD  #7    T
0016    i64 CONV   0015  i64.int sext
0017    i64 XSTORE 0011  0016
0018    p64 ADD    0010  -16 
0019 }  cdt CNEWI  +20   0018
0020 }  cdt CNEWI  +97   0018
0021    i64 XSTORE 0018  0016
0022 >  udt SLOAD  #3    T
0023    u8  FLOAD  0022  udata.udtype
0024 >  int EQ     0023  +3  
0025    p64 FLOAD  0022  sbuf.w
0026    p64 FLOAD  0022  sbuf.e
0027    i64 SUB    0026  0025
0028    int CONV   0027  int.i64 none
0029 >  int UGE    0028  +520
0030    p64 ADD    0025  +520
0031    p64 FREF   0022  sbuf.w
0032    p64 FSTORE 0031  0030
0033    int SLOAD  #4    I
0034    int ADD    0033  +1  
0035 >  int LE     0034  +60 
---- TRACE 2 mcode 264
aaaaccb8fc54  mov   x26, #4152
aaaaccb8fc58  movk  x26, #39807, lsl #16
aaaaccb8fc5c  movk  x26, #29353, lsl #32
aaaaccb8fc60  mov   x2, #3264
aaaaccb8fc64  movk  x2, #39808, lsl #16
aaaaccb8fc68  movk  x2, #62121, lsl #32
aaaaccb8fc6c  movk  x2, #65533, lsl #48
aaaaccb8fc70  mov   x1, #65529, lsl #16
aaaaccb8fc74  mov   x0, #65529, lsl #48
aaaaccb8fc78  ldr   x28, [x19]
aaaaccb8fc7c  asr   x27, x28, #47
aaaaccb8fc80  cmn   x27, #12
aaaaccb8fc84  bne   0xccb8fd6c	->0
aaaaccb8fc88  and   x28, x28, #0x7fffffffffff
aaaaccb8fc8c  ldr   w27, [x28, #52]
aaaaccb8fc90  cmp   w27, #31
aaaaccb8fc94  bne   0xccb8fd6c	->0
aaaaccb8fc98  ldr   x25, [x28, #40]
aaaaccb8fc9c  ldr   x28, [x25, #152]
aaaaccb8fca0  cmp   x28, x2
aaaaccb8fca4  bne   0xccb8fd6c	->0
aaaaccb8fca8  ldr   x28, [x25, #144]
aaaaccb8fcac  asr   x27, x28, #47
aaaaccb8fcb0  cmn   x27, #9
aaaaccb8fcb4  bne   0xccb8fd6c	->0
aaaaccb8fcb8  and   x28, x28, #0x7fffffffffff
aaaaccb8fcbc  ldr   x27, [x19, #56]
aaaaccb8fcc0  asr   x25, x27, #47
aaaaccb8fcc4  cmn   x25, #11
aaaaccb8fcc8  bne   0xccb8fd6c	->0
aaaaccb8fccc  and   x27, x27, #0x7fffffffffff
aaaaccb8fcd0  ldrh  w25, [x27, #10]
aaaaccb8fcd4  cmp   w25, #20
aaaaccb8fcd8  bne   0xccb8fd6c	->0
aaaaccb8fcdc  ldr   x27, [x27, #16]
aaaaccb8fce0  cmp   x28, x26
aaaaccb8fce4  bne   0xccb8fd6c	->0
aaaaccb8fce8  ldr   x28, [x19, #40]
aaaaccb8fcec  cmp   x1, x28, lsr #32
aaaaccb8fcf0  bne   0xccb8fd6c	->0
aaaaccb8fcf4  mov   w28, w28
aaaaccb8fcf8  sxtw  x28, w28
aaaaccb8fcfc  stp   x28, x28, [x27, #488]
aaaaccb8fd00  ldr   x27, [x19, #8]
aaaaccb8fd04  asr   x28, x27, #47
aaaaccb8fd08  cmn   x28, #13
aaaaccb8fd0c  bne   0xccb8fd74	->2
aaaaccb8fd10  and   x27, x27, #0x7fffffffffff
aaaaccb8fd14  ldrb  w28, [x27, #10]
aaaaccb8fd18  cmp   w28, #3
aaaaccb8fd1c  bne   0xccb8fd74	->2
aaaaccb8fd20  ldp   x28, x26, [x27, #48]
aaaaccb8fd24  sub   x26, x26, x28
aaaaccb8fd28  cmp   w26, #520
aaaaccb8fd2c  blo   0xccb8fd74	->2
aaaaccb8fd30  add   x28, x28, #520
aaaaccb8fd34  str   x28, [x27, #48]
aaaaccb8fd38  ldr   w28, [x19, #16]
aaaaccb8fd3c  add   w28, w28, #1
aaaaccb8fd40  cmp   w28, #60
aaaaccb8fd44  bgt   0xccb8fd78	->3
aaaaccb8fd48  add   x30, x0, w28, uxtw
aaaaccb8fd4c  str   x30, [x19, #40]
aaaaccb8fd50  add   x30, x0, w28, uxtw
aaaaccb8fd54  str   x30, [x19, #16]
aaaaccb8fd58  b     0xccb8fd80
---- TRACE 2 stop -> 1

// test case failure:
stp_failure_test_case.lua:17: 99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,99,60,0,0,0,0,0,0,0,60,0,0,0,0,0,0,0
```
after:
```
---- TRACE 2 start 1/stitch stp_failure_test_case.lua:9
0029  TGETS    8   0   8  ; "cast"       (stp_failure_test_case.lua:11)
0030  KSTR    10   9      ; "int64_t*"       (stp_failure_test_case.lua:11)
0031  ADDVN   11   7   1  ; 488       (stp_failure_test_case.lua:11)
0000  . . FUNCC               ; ffi.meta.__add
0032  CALL     8   2   3       (stp_failure_test_case.lua:11)
0000  . FUNCC               ; ffi.cast
0033  TSETB    5   8   0       (stp_failure_test_case.lua:11)
0000  . . FUNCC               ; ffi.meta.__newindex
0034  TGETS    8   0   8  ; "cast"       (stp_failure_test_case.lua:13)
0035  KSTR    10   9      ; "int64_t*"       (stp_failure_test_case.lua:13)
0036  SUBVN   11   7   0  ; 16       (stp_failure_test_case.lua:13)
0000  . . FUNCC               ; ffi.meta.__sub
0037  CALL     8   2   3       (stp_failure_test_case.lua:13)
0000  . FUNCC               ; ffi.cast
0038  TSETB    5   8   0       (stp_failure_test_case.lua:13)
0000  . . FUNCC               ; ffi.meta.__newindex
0039  MOV     10   1       (stp_failure_test_case.lua:14)
0040  TGETS    8   1  10  ; "commit"       (stp_failure_test_case.lua:14)
0041  KSHORT  11 520       (stp_failure_test_case.lua:14)
0042  CALL     8   1   3       (stp_failure_test_case.lua:14)
0000  . FUNCC               ; buffer.method.commit
0043  JFORL    2   1       (stp_failure_test_case.lua:5)
---- TRACE 2 IR
0001 >  tab SLOAD  #2    T
0002    int FLOAD  0001  tab.hmask
0003 >  int EQ     0002  +31 
0004    p64 FLOAD  0001  tab.node
0005 >  p64 HREFK  0004  "cast" @6
0006 >  fun HLOAD  0005
0007 >  cdt SLOAD  #9    T
0008    u16 FLOAD  0007  cdata.ctypeid
0009 >  int EQ     0008  +20 
0010    p64 FLOAD  0007  cdata.ptr
0011    p64 ADD    0010  +488
0012 }  cdt CNEWI  +20   0011
0013 >  fun EQ     0006  ffi.cast
0014 }  cdt CNEWI  +97   0011
0015 >  int SLOAD  #7    T
0016    i64 CONV   0015  i64.int sext
0017    i64 XSTORE 0011  0016
0018    p64 ADD    0010  -16 
0019 }  cdt CNEWI  +20   0018
0020 }  cdt CNEWI  +97   0018
0021    i64 XSTORE 0018  0016
0022 >  udt SLOAD  #3    T
0023    u8  FLOAD  0022  udata.udtype
0024 >  int EQ     0023  +3  
0025    p64 FLOAD  0022  sbuf.w
0026    p64 FLOAD  0022  sbuf.e
0027    i64 SUB    0026  0025
0028    int CONV   0027  int.i64 none
0029 >  int UGE    0028  +520
0030    p64 ADD    0025  +520
0031    p64 FREF   0022  sbuf.w
0032    p64 FSTORE 0031  0030
0033    int SLOAD  #4    I
0034    int ADD    0033  +1  
0035 >  int LE     0034  +60 
---- TRACE 2 mcode 268
aaaaba5dfc50  mov   x26, #16440
aaaaba5dfc54  movk  x26, #7252, lsl #16
aaaaba5dfc58  movk  x26, #28876, lsl #32
aaaaba5dfc5c  mov   x2, #15536
aaaaba5dfc60  movk  x2, #7253, lsl #16
aaaaba5dfc64  movk  x2, #61644, lsl #32
aaaaba5dfc68  movk  x2, #65533, lsl #48
aaaaba5dfc6c  mov   x1, #65529, lsl #16
aaaaba5dfc70  mov   x0, #65529, lsl #48
aaaaba5dfc74  ldr   x28, [x19]
aaaaba5dfc78  asr   x27, x28, #47
aaaaba5dfc7c  cmn   x27, #12
aaaaba5dfc80  bne   0xba5dfd6c	->0
aaaaba5dfc84  and   x28, x28, #0x7fffffffffff
aaaaba5dfc88  ldr   w27, [x28, #52]
aaaaba5dfc8c  cmp   w27, #31
aaaaba5dfc90  bne   0xba5dfd6c	->0
aaaaba5dfc94  ldr   x25, [x28, #40]
aaaaba5dfc98  ldr   x28, [x25, #152]
aaaaba5dfc9c  cmp   x28, x2
aaaaba5dfca0  bne   0xba5dfd6c	->0
aaaaba5dfca4  ldr   x28, [x25, #144]
aaaaba5dfca8  asr   x27, x28, #47
aaaaba5dfcac  cmn   x27, #9
aaaaba5dfcb0  bne   0xba5dfd6c	->0
aaaaba5dfcb4  and   x28, x28, #0x7fffffffffff
aaaaba5dfcb8  ldr   x27, [x19, #56]
aaaaba5dfcbc  asr   x25, x27, #47
aaaaba5dfcc0  cmn   x25, #11
aaaaba5dfcc4  bne   0xba5dfd6c	->0
aaaaba5dfcc8  and   x27, x27, #0x7fffffffffff
aaaaba5dfccc  ldrh  w25, [x27, #10]
aaaaba5dfcd0  cmp   w25, #20
aaaaba5dfcd4  bne   0xba5dfd6c	->0
aaaaba5dfcd8  ldr   x27, [x27, #16]
aaaaba5dfcdc  cmp   x28, x26
aaaaba5dfce0  bne   0xba5dfd6c	->0
aaaaba5dfce4  ldr   x28, [x19, #40]
aaaaba5dfce8  cmp   x1, x28, lsr #32
aaaaba5dfcec  bne   0xba5dfd6c	->0
aaaaba5dfcf0  mov   w28, w28
aaaaba5dfcf4  sxtw  x28, w28
aaaaba5dfcf8  str   x28, [x27, #488]
aaaaba5dfcfc  stur  x28, [x27, #-16]
aaaaba5dfd00  ldr   x27, [x19, #8]
aaaaba5dfd04  asr   x28, x27, #47
aaaaba5dfd08  cmn   x28, #13
aaaaba5dfd0c  bne   0xba5dfd74	->2
aaaaba5dfd10  and   x27, x27, #0x7fffffffffff
aaaaba5dfd14  ldrb  w28, [x27, #10]
aaaaba5dfd18  cmp   w28, #3
aaaaba5dfd1c  bne   0xba5dfd74	->2
aaaaba5dfd20  ldp   x28, x26, [x27, #48]
aaaaba5dfd24  sub   x26, x26, x28
aaaaba5dfd28  cmp   w26, #520
aaaaba5dfd2c  blo   0xba5dfd74	->2
aaaaba5dfd30  add   x28, x28, #520
aaaaba5dfd34  str   x28, [x27, #48]
aaaaba5dfd38  ldr   w28, [x19, #16]
aaaaba5dfd3c  add   w28, w28, #1
aaaaba5dfd40  cmp   w28, #60
aaaaba5dfd44  bgt   0xba5dfd78	->3
aaaaba5dfd48  add   x30, x0, w28, uxtw
aaaaba5dfd4c  str   x30, [x19, #40]
aaaaba5dfd50  add   x30, x0, w28, uxtw
aaaaba5dfd54  str   x30, [x19, #16]
aaaaba5dfd58  b     0xba5dfd80
---- TRACE 2 stop -> 1

```
