### PR TITLE
[RFC] Initial support on cross-compiling LuaJIT from x64 to ARM64 in MSVC.

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -7,3 +7,4 @@ lj_libdef.h
 lj_recdef.h
 lj_folddef.h
 lj_vm.[sS]
+.luajit_msvc_arm64_phase1

--- a/src/msvcbuild_arm64.bat
+++ b/src/msvcbuild_arm64.bat
@@ -1,0 +1,141 @@
+@rem Script to build LuaJIT with MSVC cross-compiling to Windows ARM64.
+@rem Copyright (C) 2005-2023 Mike Pall. See Copyright Notice in luajit.h
+@rem
+@rem Open a "Visual Studio Command Prompt" (x64 first then arm64).
+@rem Then cd to this directory and run this script. Use the following
+@rem options (in order), if needed. The default is a dynamic release build.
+@rem
+@rem   debug    emit debug symbols
+@rem   amalg    amalgamated build
+@rem   static   static linkage
+
+@if not defined INCLUDE goto :FAIL
+
+@setlocal
+@rem Add more debug flags here, e.g. DEBUGCFLAGS=/DLUA_USE_APICHECK
+@set DEBUGCFLAGS=
+@set LJCOMPILE=cl /nologo /c /O2 /W3 /D_CRT_SECURE_NO_DEPRECATE /D_CRT_STDIO_INLINE=__declspec(dllexport)__inline
+@set LJLINK=link /nologo
+@set LJMT=mt /nologo
+@set LJLIB=lib /nologo /nodefaultlib
+@set DASMDIR=..\dynasm
+@set DASM=%DASMDIR%\dynasm.lua
+@set DASC=vm_x64.dasc
+@set LJDLLNAME=lua51.dll
+@set LJLIBNAME=lua51.lib
+@set BUILDTYPE=release
+@set ALL_LIB=lib_base.c lib_math.c lib_bit.c lib_string.c lib_table.c lib_io.c lib_os.c lib_package.c lib_debug.c lib_jit.c lib_ffi.c lib_buffer.c
+
+@set DASMFLAGS=-D WIN -D JIT -D FFI -D ENDIAN_LE -D FPU -D P64 -D DUALNUM
+@set DASC=vm_arm64.dasc
+@set LJARCH=arm64
+
+@if "%VSCMD_ARG_TGT_ARCH%" equ "arm64" goto :ARM64
+@if "%VSCMD_ARG_TGT_ARCH%" neq "x64" goto :X64FAIL
+
+%LJCOMPILE% host\minilua.c
+@if errorlevel 1 goto :BAD
+%LJLINK% /out:minilua.exe minilua.obj
+@if errorlevel 1 goto :BAD
+if exist minilua.exe.manifest^
+  %LJMT% -manifest minilua.exe.manifest -outputresource:minilua.exe
+
+@minilua
+@if errorlevel 8 goto :YES64
+@echo Mismatch with minilua size types.
+@goto :BAD
+:YES64
+
+minilua %DASM% -LN %DASMFLAGS% -o host\buildvm_arch.h %DASC%
+@if errorlevel 1 goto :BAD
+
+if exist ..\.git ( git show -s --format=%%ct >luajit_relver.txt ) else ( type ..\.relver >luajit_relver.txt )
+minilua host\genversion.lua
+
+%LJCOMPILE% /I "." /I %DASMDIR% host\buildvm*.c /DLUAJIT_TARGET=LUAJIT_ARCH_ARM64
+@if errorlevel 1 goto :BAD
+%LJLINK% /out:buildvm.exe buildvm*.obj
+@if errorlevel 1 goto :BAD
+if exist buildvm.exe.manifest^
+  %LJMT% -manifest buildvm.exe.manifest -outputresource:buildvm.exe
+
+@echo. > .luajit_msvc_arm64_phase1
+@echo === Now rerun this script using ARM64 toolchain ===
+@goto :END
+
+:ARM64
+@if not exist .luajit_msvc_arm64_phase1 goto :ARM64FAIL
+
+buildvm -m peobj -o lj_vm.obj
+@if errorlevel 1 goto :BAD
+buildvm -m bcdef -o lj_bcdef.h %ALL_LIB%
+@if errorlevel 1 goto :BAD
+buildvm -m ffdef -o lj_ffdef.h %ALL_LIB%
+@if errorlevel 1 goto :BAD
+buildvm -m libdef -o lj_libdef.h %ALL_LIB%
+@if errorlevel 1 goto :BAD
+buildvm -m recdef -o lj_recdef.h %ALL_LIB%
+@if errorlevel 1 goto :BAD
+buildvm -m vmdef -o jit\vmdef.lua %ALL_LIB%
+@if errorlevel 1 goto :BAD
+buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
+@if errorlevel 1 goto :BAD
+
+@if "%1" neq "debug" goto :NODEBUG
+@shift
+@set BUILDTYPE=debug
+@set LJCOMPILE=%LJCOMPILE% /Zi %DEBUGCFLAGS%
+@set LJLINK=%LJLINK% /opt:ref /opt:icf /incremental:no
+:NODEBUG
+@set LJLINK=%LJLINK% /%BUILDTYPE%
+@if "%1"=="amalg" goto :AMALGDLL
+@if "%1"=="static" goto :STATIC
+%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL lj_*.c lib_*.c
+@if errorlevel 1 goto :BAD
+%LJLINK% /DLL /out:%LJDLLNAME% lj_*.obj lib_*.obj
+@if errorlevel 1 goto :BAD
+@goto :MTDLL
+:STATIC
+%LJCOMPILE% lj_*.c lib_*.c
+@if errorlevel 1 goto :BAD
+%LJLIB% /OUT:%LJLIBNAME% lj_*.obj lib_*.obj
+@if errorlevel 1 goto :BAD
+@goto :MTDLL
+:AMALGDLL
+%LJCOMPILE% /MD /DLUA_BUILD_AS_DLL ljamalg.c
+@if errorlevel 1 goto :BAD
+%LJLINK% /DLL /out:%LJDLLNAME% ljamalg.obj lj_vm.obj
+@if errorlevel 1 goto :BAD
+:MTDLL
+if exist %LJDLLNAME%.manifest^
+  %LJMT% -manifest %LJDLLNAME%.manifest -outputresource:%LJDLLNAME%;2
+
+%LJCOMPILE% luajit.c
+@if errorlevel 1 goto :BAD
+%LJLINK% /out:luajit.exe luajit.obj %LJLIBNAME%
+@if errorlevel 1 goto :BAD
+if exist luajit.exe.manifest^
+  %LJMT% -manifest luajit.exe.manifest -outputresource:luajit.exe
+
+@del *.obj *.manifest minilua.exe buildvm.exe .luajit_msvc_arm64_phase1
+@del host\buildvm_arch.h
+@del lj_bcdef.h lj_ffdef.h lj_libdef.h lj_recdef.h lj_folddef.h
+@echo.
+@echo === Successfully built LuaJIT for Windows/%LJARCH% ===
+
+@goto :END
+:X64FAIL
+@echo Building for ARM64 requires x64 toolchain.
+@goto :END
+:ARM64FAIL
+@echo Please run this script with x64 toolchain first.
+@goto :END
+:BAD
+@echo.
+@echo *******************************************************
+@echo *** Build FAILED -- Please check the error messages ***
+@echo *******************************************************
+@goto :END
+:FAIL
+@echo You must open a "Visual Studio Command Prompt" to run this script
+:END


### PR DESCRIPTION
So this is rather to be used as reference instead of being merged as-is or with changes. A supplementary addition to #593.

This cross-compile method is rather unpleasant but I don't think there's other way to do it if using official toolchain is absolutely required. From https://github.com/LuaJIT/LuaJIT/issues/593#issuecomment-727601544:
> As a side note, looks like two invocations to `VsDevCmd.bat` is required. One for setting up the host compiler and one for setting up the cross compiler, since the executable name for the host compiler and the cross compiler is both `cl.exe` which can't be distinguished. This ultimately requires "Developer Command Prompt" to be used.

However, there's another alternative: Using LLVM `clang` or `clang-cl` (with working MSVC toolchain) and `--target` flag, it's possible to compile both for x64 (using `--target=x86_64-pc-win32`) and ARM64 (using `--target=aarch64-pc-win32`). The plus point is there's no need to setup for Developer Command Prompt (Clang handle this for you). It should be easy to build batch file using this method instead if desired.

To build with this script:
1. Run `VsDevCmd.bat -arch=x64 -host_arch=amd64` to setup the host compiler.
2. Run `msvcbuild_arm64.bat`. This builds `minilua.exe` and `buildvm.exe` for x64.
3. Run `VsDevCmd.bat -arch=arm64 -host_arch=amd64` to setup the cross compiler.
4. Run `msvcbuild_arm64.bat` **again**. Ensure to have same options as in step 2. This will build the rest of LuaJIT for ARM64.

Two separate terminal can be used for step 1 & 2 and 3 & 4. Compilation with default option, `amalg`, and `debug` option works. `static` doesn't seem to work for some reason (compiles successfully but it still tries to look for lua51.dll). Rolling release version is embedded correctly (looked through `strings luajit.exe`).

Note that there's no way for me to tell if the resulting executable works. I don't have the hardware needed to test it out.