### PR TITLE
Invalidate SCEV entry when it is out of scope.

### DIFF
--- a/src/lj_record.c
+++ b/src/lj_record.c
@@ -976,6 +976,8 @@ void lj_record_ret(jit_State *J, BCReg rbase, ptrdiff_t gotresults)
       emitir(IRTG(IR_RETF, IRT_PGC), trpt, trpc);
       J->retdepth++;
       J->needsnap = 1;
+      /* scev entry is invalid after returning to lower frame. */
+      J->scev.idx = REF_NIL;
       lj_assertJ(J->baseslot == 1+LJ_FR2, "bad baseslot for return");
       /* Shift result slots up and clear the slots of the new frame below. */
       memmove(J->base + cbase, J->base-1-LJ_FR2, sizeof(TRef)*nresults);


### PR DESCRIPTION
Fix the assertion error in the following example:
``` lua
local function find(data)
  local function find_a(data)
        for i = 1, #data-1 do
          if data[i].t == "a" and data[i+1].t == "b" then
            return i+1
          end
        end
        return nil
      end

      local function find_b(data, start)
         local pos = #data
         for i = start, #data-1 do
            if data[i].t == "a" then
               pos = i-1
               break
            end
         end
      end

      local start = find_a(data)
      return start, find_b(data, start)
end

local data = {}
for i = 1, 69 do
  data[#data+1] = { t = "a"..i }
end

data[57] = {
    l = "",
    m = "",
    t = "a1",
}

data[67] = { t = "a" }
data[68] = { t = "b" }
find(data)
print(3)
```
When `LUA_USE_ASSERT` is enabled, it will run into error like `LuaJIT ASSERT lj_obj.h:1022: numberVint: tvisnum(o)`. Here is the related dump from above test case:
```
---- TRACE 2 start markdown_mini.lua:3
0006  TGETV    5   0   4
0007  TGETS    5   5   0  ; "t"
0008  ISNES    5   1      ; "a"
0009  JMP      5 => 0017
0017  FORL     1 => 0006
---- TRACE 2 IR
....        SNAP   #0   [ ---- ---- ]
0001 >  int SLOAD  #4    CRI
0002 >  int LE     0001  +2147483646
0003    int SLOAD  #3    CI
0004 >  tab SLOAD  #2    T
0005    int FLOAD  0004  tab.asize
0006 >  p32 ABC    0005  0001
0007    p64 FLOAD  0004  tab.array
0008    p64 AREF   0007  0003
0009 >  tab ALOAD  0008
0010    int FLOAD  0009  tab.hmask
0011 >  int EQ     0010  +3  
0012    p64 FLOAD  0009  tab.node
0013 >  p64 HREFK  0012  "t"  @1
0014 >  str HLOAD  0013
....        SNAP   #1   [ ---- ---- ---- 0003 0001 ---- 0003 ]
0015 >  str NE     0014  "a" 
0016  + int ADD    0003  +1  
....        SNAP   #2   [ ---- ---- ---- ]
0017 >  int LE     0016  0001
....        SNAP   #3   [ ---- ---- ---- 0016 0001 ---- 0016 ]
0018 ------ LOOP ------------
0019    p64 AREF   0007  0016
0020 >  tab ALOAD  0019
0021    int FLOAD  0020  tab.hmask
0022 >  int EQ     0021  +3  
0023    p64 FLOAD  0020  tab.node
0024 >  p64 HREFK  0023  "t"  @1
0025 >  str HLOAD  0024
....        SNAP   #4   [ ---- ---- ---- 0016 0001 ---- 0016 ]
0026 >  str NE     0025  "a" 
0027  + int ADD    0016  +1  
....        SNAP   #5   [ ---- ---- ---- ]
0028 >  int LE     0027  0001
0029    int PHI    0016  0027
---- TRACE 2 stop -> loop

---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0                     -- comment, exit == 0 will trigger forming an extra loop in TRACE 3
                                                    -- and it will record the scev entry.
---- TRACE 3 start 2/0 markdown_mini.lua:4
0006  TGETV    5   0   4
0007  TGETS    5   5   0  ; "t"
0008  ISNES    5   1      ; "a"
0009  JMP      5 => 0017
0010  ADDVN    5   4   0  ; 1
0011  TGETV    5   0   5
0012  TGETS    5   5   0  ; "t"
0013  ISNES    5   2      ; "b"
0014  JMP      5 => 0017
0015  ADDVN    5   4   0  ; 1
0016  RET1     5   2                    -- comment, the scev entry is invalid after this point.
0006  MOV      4   3
0007  MOV      5   2
0008  MOV      7   0
0009  MOV      8   3
0010  CALL     5   0   3
0000  . FUNCF    8          ; markdown_mini.lua:11
0001  . LEN      2   0
0002  . MOV      3   1
0003  . LEN      4   0
0004  . SUBVN    4   4   0  ; 1
0005  . KSHORT   5   1
0006  . FORI     3 => 0014
0007  . TGETV    7   0   6           -- comment, we are using invalid scev entry at this instruction and cause the following error.
LuaJIT ASSERT lj_obj.h:1022: numberVint: tvisnum(o)
```

After this change, the above case will pass with the follow dump:
```
---- TRACE 2 start markdown_mini.lua:3
0006  TGETV    5   0   4
0007  TGETS    5   5   0  ; "t"
0008  ISNES    5   1      ; "a"
0009  JMP      5 => 0017
0017  FORL     1 => 0006
---- TRACE 2 IR
....        SNAP   #0   [ ---- ---- ]
0001 >  int SLOAD  #4    CRI
0002 >  int LE     0001  +2147483646
0003    int SLOAD  #3    CI
0004 >  tab SLOAD  #2    T
0005    int FLOAD  0004  tab.asize
0006 >  p32 ABC    0005  0001
0007    p64 FLOAD  0004  tab.array
0008    p64 AREF   0007  0003
0009 >  tab ALOAD  0008
0010    int FLOAD  0009  tab.hmask
0011 >  int EQ     0010  +3  
0012    p64 FLOAD  0009  tab.node
0013 >  p64 HREFK  0012  "t"  @3
0014 >  str HLOAD  0013
....        SNAP   #1   [ ---- ---- ---- 0003 0001 ---- 0003 ]
0015 >  str NE     0014  "a" 
0016  + int ADD    0003  +1  
....        SNAP   #2   [ ---- ---- ---- ]
0017 >  int LE     0016  0001
....        SNAP   #3   [ ---- ---- ---- 0016 0001 ---- 0016 ]
0018 ------ LOOP ------------
0019    p64 AREF   0007  0016
0020 >  tab ALOAD  0019
0021    int FLOAD  0020  tab.hmask
0022 >  int EQ     0021  +3  
0023    p64 FLOAD  0020  tab.node
0024 >  p64 HREFK  0023  "t"  @3
0025 >  str HLOAD  0024
....        SNAP   #4   [ ---- ---- ---- 0016 0001 ---- 0016 ]
0026 >  str NE     0025  "a" 
0027  + int ADD    0016  +1  
....        SNAP   #5   [ ---- ---- ---- ]
0028 >  int LE     0027  0001
0029    int PHI    0016  0027
---- TRACE 2 stop -> loop

---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 2 exit 0
---- TRACE 3 start 2/0 markdown_mini.lua:4
0006  TGETV    5   0   4
0007  TGETS    5   5   0  ; "t"
0008  ISNES    5   1      ; "a"
0009  JMP      5 => 0017
0010  ADDVN    5   4   0  ; 1
0011  TGETV    5   0   5
0012  TGETS    5   5   0  ; "t"
0013  ISNES    5   2      ; "b"
0014  JMP      5 => 0017
0015  ADDVN    5   4   0  ; 1
0016  RET1     5   2
0006  MOV      4   3
0007  MOV      5   2
0008  MOV      7   0
0009  MOV      8   3
0010  CALL     5   0   3
0000  . FUNCF    8          ; markdown_mini.lua:11
0001  . LEN      2   0
0002  . MOV      3   1
0003  . LEN      4   0
0004  . SUBVN    4   4   0  ; 1
0005  . KSHORT   5   1
0006  . FORI     3 => 0014
0007  . TGETV    7   0   6
0008  . TGETS    7   7   0  ; "t"
0009  . ISNES    7   1      ; "a"
0010  . JMP      7 => 0013
0013  . FORL     3 => 0007
0014  . RET0     0   1
0011  UCLO     0 => 0012
---- TRACE 3 abort markdown_mini.lua:22 -- NYI: bytecode 50
```