### PR TITLE
Fixed incorrect ".debug_abbrev" section termination

### DIFF
--- a/src/lj_gdbjit.c
+++ b/src/lj_gdbjit.c
@@ -637,7 +637,7 @@ static void LJ_FASTCALL gdbjit_debugabbrev(GDBJITctx *ctx)
   DUV(DW_AT_low_pc);	DUV(DW_FORM_addr);
   DUV(DW_AT_high_pc);	DUV(DW_FORM_addr);
   DUV(DW_AT_stmt_list);	DUV(DW_FORM_data4);
-  DB(0); DB(0);
+  DB(0); DB(0); DB(0);
 
   ctx->p = p;
 }


### PR DESCRIPTION
Incorrect terminataion of the section causes GDB to read after the end of the section This leads to unpredictable behavior (dwarf warnings, etc). The problem is well visible when runing GDB under VALGRIND.

$ valgrind gdb --args luajit test.lua
(gdb) r

The affected GDB code

https://github.com/bminor/binutils-gdb/blob/master/gdb/dwarf2/abbrev.c#L138