### PR TITLE
DynASM/x64: Allow "&expr" syntax in MRM to generate IP-relative code

### DIFF
--- a/dynasm/dasm_x86.lua
+++ b/dynasm/dasm_x86.lua
@@ -478,7 +478,7 @@ local function wputdarg(n)
     wputb(band(shr(n, 16), 255))
     wputb(shr(n, 24))
   elseif tn == "table" then
-    wputlabel("IMM_", n[1], 1)
+    wputlabel("IMM_", n[2], 1)
   else
     waction("IMM_D", n)
   end
@@ -627,7 +627,11 @@ local function wputmrmsib(t, imark, s, vsreg, psz, sk)
 	werror("NYI: rip-relative displacement followed by immediate")
       end
       -- The previous byte in the action buffer cannot be 0xe9 or 0x80-0x8f.
-      wputlabel("REL_", disp[1], 2)
+      if disp[1] == "iPJ" then
+	waction("REL_A", disp[2])
+      else
+	wputlabel("REL_", disp[2], 2)
+      end
     else
       wputdarg(disp)
     end
@@ -744,9 +748,9 @@ local function dispexpr(expr)
     return imm*map_opsizenum[ops]
   end
   local mode, iexpr = immexpr(dispt)
-  if mode == "iJ" then
+  if mode == "iJ" or mode == "iPJ" then
     if c == "-" then werror("cannot invert label reference") end
-    return { iexpr }
+    return { mode, iexpr }
   end
   return expr -- Need to return original signed expression.
 end


### PR DESCRIPTION
DynASM already allows usage of jump taget syntax in x86 MRM

| mov rax, [->1]

On x86_86 this leads to generatation of IP-realtive code. but for some reason  "&expr" jump target syntax is not supported. The patch enables this syntax, so now we may write

| mov rcx, [&addr]

instead of

| mov64 rcx, &addr
| mov rcx, [rcx]