### PR TITLE
Add support for ENDBR instructions

### DIFF
--- a/dynasm/dasm_x86.lua
+++ b/dynasm/dasm_x86.lua
@@ -1151,6 +1151,8 @@ local map_op = {
   rep_0 =	"F3",
   repe_0 =	"F3",
   repz_0 =	"F3",
+  endbr32_0 =	"F30F1EFB",
+  endbr64_0 =	"F30F1EFA",
   -- F4: *hlt
   cmc_0 =	"F5",
   -- F6: test... mb,i; div... mb


### PR DESCRIPTION
These instructions are useful to support Intel Control-flow Enforcement Technology (CET), when JIT code is called through idirect jump.

See `man gcc` "-fcf-protection" and https://www.felixcloutier.com/x86/endbr64