### PR TITLE
Fixed compiler error for LuaJIT rolling header inside C++ header

### DIFF
--- a/src/lua.hpp
+++ b/src/lua.hpp
@@ -4,6 +4,6 @@ extern "C" {
 #include "lua.h"
 #include "lauxlib.h"
 #include "lualib.h"
-#include "luajit.h"
+#include "luajit_rolling.h"
 }
 


### PR DESCRIPTION
Updated header name for the lua.hpp header:
include luajit_rolling.h instead of luajit.h, fixed compilation error