### PR TITLE
Prevent Lua VM re-entry through JIT trace.

### DIFF
--- a/src/lj_api.c
+++ b/src/lj_api.c
@@ -92,6 +92,18 @@ static GCtab *getcurrenv(lua_State *L)
   return fn->c.gct == ~LJ_TFUNC ? tabref(fn->c.env) : tabref(L->env);
 }
 
+static void check_vm_sandwich(lua_State *L)
+{
+  global_State *g = G(L);
+  /* Forbid Lua world re-entry while running the trace */
+  if (tvref(g->jit_base)) {
+    setstrV(L, L->top++, lj_err_str(L, LJ_ERR_JITREVM));
+    if (g->panic) g->panic(L);
+    exit(EXIT_FAILURE);
+  }
+  lj_trace_abort(g);  /* Never record across Lua VM entrance */
+}
+
 /* -- Miscellaneous API functions ----------------------------------------- */
 
 LUA_API int lua_status(lua_State *L)
@@ -318,6 +330,7 @@ LUA_API int lua_equal(lua_State *L, int idx1, int idx2)
       return (int)(uintptr_t)base;
     } else {
       L->top = base+2;
+      check_vm_sandwich(L);
       lj_vm_call(L, base, 1+1);
       L->top -= 2+LJ_FR2;
       return tvistruecond(L->top+1+LJ_FR2);
@@ -341,6 +354,7 @@ LUA_API int lua_lessthan(lua_State *L, int idx1, int idx2)
       return (int)(uintptr_t)base;
     } else {
       L->top = base+2;
+      check_vm_sandwich(L);
       lj_vm_call(L, base, 1+1);
       L->top -= 2+LJ_FR2;
       return tvistruecond(L->top+1+LJ_FR2);
@@ -786,6 +800,7 @@ LUA_API void lua_concat(lua_State *L, int n)
       }
       n -= (int)(L->top - (top - 2*LJ_FR2));
       L->top = top+2;
+      check_vm_sandwich(L);
       lj_vm_call(L, top, 1+1);
       L->top -= 1+LJ_FR2;
       copyTV(L, L->top-1, L->top+LJ_FR2);
@@ -805,6 +820,7 @@ LUA_API void lua_gettable(lua_State *L, int idx)
   cTValue *v = lj_meta_tget(L, t, L->top-1);
   if (v == NULL) {
     L->top += 2;
+    check_vm_sandwich(L);
     lj_vm_call(L, L->top-2, 1+1);
     L->top -= 2+LJ_FR2;
     v = L->top+1+LJ_FR2;
@@ -820,6 +836,7 @@ LUA_API void lua_getfield(lua_State *L, int idx, const char *k)
   v = lj_meta_tget(L, t, &key);
   if (v == NULL) {
     L->top += 2;
+    check_vm_sandwich(L);
     lj_vm_call(L, L->top-2, 1+1);
     L->top -= 2+LJ_FR2;
     v = L->top+1+LJ_FR2;
@@ -978,6 +995,7 @@ LUA_API void lua_settable(lua_State *L, int idx)
     TValue *base = L->top;
     copyTV(L, base+2, base-3-2*LJ_FR2);
     L->top = base+3;
+    check_vm_sandwich(L);
     lj_vm_call(L, base, 0+1);
     L->top -= 3+LJ_FR2;
   }
@@ -998,6 +1016,7 @@ LUA_API void lua_setfield(lua_State *L, int idx, const char *k)
     TValue *base = L->top;
     copyTV(L, base+2, base-3-2*LJ_FR2);
     L->top = base+3;
+    check_vm_sandwich(L);
     lj_vm_call(L, base, 0+1);
     L->top -= 2+LJ_FR2;
   }
@@ -1129,6 +1148,7 @@ LUA_API void lua_call(lua_State *L, int nargs, int nresults)
   lj_checkapi(L->status == LUA_OK || L->status == LUA_ERRERR,
 	      "thread called in wrong state %d", L->status);
   lj_checkapi_slot(nargs+1);
+  check_vm_sandwich(L);
   lj_vm_call(L, api_call_base(L, nargs), nresults+1);
 }
 
@@ -1147,6 +1167,7 @@ LUA_API int lua_pcall(lua_State *L, int nargs, int nresults, int errfunc)
     cTValue *o = index2adr_stack(L, errfunc);
     ef = savestack(L, o);
   }
+  check_vm_sandwich(L);
   status = lj_vm_pcall(L, api_call_base(L, nargs), nresults+1, ef);
   if (status) hook_restore(g, oldh);
   return status;
@@ -1175,6 +1196,7 @@ LUA_API int lua_cpcall(lua_State *L, lua_CFunction func, void *ud)
   int status;
   lj_checkapi(L->status == LUA_OK || L->status == LUA_ERRERR,
 	      "thread called in wrong state %d", L->status);
+  check_vm_sandwich(L);
   status = lj_vm_cpcall(L, func, ud, cpcall);
   if (status) hook_restore(g, oldh);
   return status;
@@ -1187,6 +1209,7 @@ LUALIB_API int luaL_callmeta(lua_State *L, int idx, const char *field)
     if (LJ_FR2) setnilV(top++);
     copyTV(L, top++, index2adr(L, idx));
     L->top = top;
+    check_vm_sandwich(L);
     lj_vm_call(L, top-1, 1+1);
     return 1;
   }

--- a/src/lj_errmsg.h
+++ b/src/lj_errmsg.h
@@ -109,6 +109,7 @@ ERRDEF(NOJIT,	"no JIT compiler for this architecture (yet)")
 ERRDEF(NOJIT,	"JIT compiler permanently disabled by build option")
 #endif
 ERRDEF(JITOPT,	"unknown or malformed optimization flag " LUA_QS)
+ERRDEF(JITREVM,	"Lua VM re-entry is detected while executing the trace")
 
 /* Lexer/parser errors. */
 ERRDEF(XMODE,	"attempt to load chunk with wrong mode")


### PR DESCRIPTION
### TL;DR:

I'd like to upstream the patch (tarantool/luajit@4f4fd9eb) implemented almost 4 years ago to prevent Tarantool crashes caused by FFI machinery misuse (see tarantool/tarantool#4427 for more info), that is widely exploited in Tarantool sources. The Tarantool issue has been fixed, and no related crashes has occurred since the patch has been applied to the long-term branches within our LuaJIT fork. Hence, I decided to try landing this patch to the upstream considering the fact #1066 is finally aboard.

@MikePall, I'm OK if you don't want to apply the changeset; at least the misuse will be described here and someone exploiting any FFI holes (*I'm completely against this*) will know the symptoms and the pill.

---

### Description

JIT recording semantics assumes FFI calls are leaf regarding the LuaJIT VM: if the execution exited Lua world through FFI machinery it is not re-entering Lua world again.

However, there is a way to break this assumption via FFI: one can re-enter LuaJIT VM via Lua C API, used within the particular C routine called via FFI. As a result the following host stack mix is created:
> Lua-FFI -> C routine -> Lua-C API -> Lua VM

This sort of re-entry is not supported by LuaJIT tracing compiler. @mraleph named such kind of the call stack an "FFI sandwich" in the tarantool/tarantool#4427.

This changeset introduces the mechanism for Lua-C API callbacks similar to the one implemented for Lua-FFI: trace recording is aborted when the execution re-enters LuaJIT VM. If the re-enter is detected while running the particular mcode, the runtime finishes its execution with `EXIT_FAILURE` code and calls the panic routine prior to the exit.

The patch slightly differs from the one committed via tarantool/luajit@4f4fd9eb, but all the changes are cosmetic to make the original idea more clear.

---

### How to reproduce the bug:

<details>
 <summary>libsandwich.c</summary>
 
 ```c
#include <lua.h>
#include <lauxlib.h>

struct sandwich {
	lua_State *L; /* Coroutine saved for a Lua call */
	int ref;      /* Anchor to the Lua function to be run */
	int trigger;  /* Trigger for switching to Lua call */
};

int increment(struct sandwich *state, int i)
{
	if (i < state->trigger)
		return i + 1;

	/* Sandwich is triggered and Lua increment function is called */
	lua_pushnumber(state->L, state->ref);
	lua_gettable(state->L, LUA_REGISTRYINDEX);
	lua_pushnumber(state->L, i);
	lua_call(state->L, 1, 1);
	return lua_tonumber(state->L, -1);
}

#define STRUCT_SANDWICH_MT "struct sandwich"

static int init(lua_State *L)
{
	struct sandwich *state = lua_newuserdata(L, sizeof(struct sandwich));

	luaL_getmetatable(L, STRUCT_SANDWICH_MT);
	lua_setmetatable(L, -2);

	/* Lua increment function to be called when sandwich is triggered */
	if (luaL_dostring(L, "return function(i) return i + 1 end"))
		luaL_error(L, "failed to translate Lua increment function");

	state->ref = luaL_ref(L, LUA_REGISTRYINDEX);
	state->L = L;
	state->trigger = lua_tonumber(L, 1);
	return 1;
}

static int fin(lua_State *L)
{
	struct sandwich *state = luaL_checkudata(L, 1, STRUCT_SANDWICH_MT);

	/* Release the anchored increment function */
	luaL_unref(L, LUA_REGISTRYINDEX, state->ref);
	return 0;
}

LUA_API int luaopen_libsandwich(lua_State *L)
{
	luaL_newmetatable(L, STRUCT_SANDWICH_MT);
	lua_pushcfunction(L, fin);
	lua_setfield(L, -2, "__gc");

	lua_pushcfunction(L, init);
	return 1;
}
  ```
</details>
<details>
 <summary>sandwich.lua</summary>
 
 ```lua
local ffi = require('ffi')
local ffisandwich = ffi.load('libsandwich')
ffi.cdef('int increment(struct sandwich *state, int i)')

local cfg = {
  hotloop = arg[1] or 1,
  trigger = arg[2] or 1,
}

-- Save the current coroutine and set the value to trigger
-- <increment> to call the Lua routine instead of C implementation.
local sandwich = require('libsandwich')(cfg.trigger)

-- Depending on the trigger and hotloop values the following contexts
-- are possible:
-- * if trigger <= hotloop -> trace recording is aborted
-- * if trigger >  hotloop -> trace is recorded but execution
--   leads to panic
jit.opt.start("3", string.format("hotloop=%d", cfg.hotloop))

local res
for i = 0, cfg.trigger + cfg.hotloop do
  res = ffisandwich.increment(sandwich, i)
end
-- Check the resulting value if the panic didn't occur earlier.
print(res)

 ```
</details>

```
$ pwd
/LuaJIT
$ make -j
<snipped>
$ gcc -fPIC -shared -Isrc libsandwich.c -o libsandwich.so
$ LD_LIBRARY_PATH=. ./src/luajit test.lua 1 1 
3
$ LD_LIBRARY_PATH=. ./src/luajit test.lua 1 2
[1]    29035 segmentation fault  LD_LIBRARY_PATH=. ./src/luajit test.lua 1 2
```

As a result of the patch the last command ends the following way
```
$ LD_LIBRARY_PATH=. ./src/luajit test.lua 1 2
PANIC: unprotected error in call to Lua API (Lua VM re-entry is detected while executing the trace)
```

---

Co-authored-by: Vyacheslav Egorov <vegorov@google.com>
Co-authored-by: Sergey Ostanevich <sergos@tarantool.org>
Signed-off-by: Igor Munkin <imun@cpan.org>