### PR TITLE
Fix OSX 10.6 / iOS 4.2

### DIFF
--- a/src/lj_prng.c
+++ b/src/lj_prng.c
@@ -227,7 +227,12 @@ int LJ_FASTCALL lj_prng_seed_secure(PRNGState *rs)
   ** or the OS ran out of file descriptors.
   */
   {
+#ifdef O_CLOEXEC
     int fd = open("/dev/urandom", O_RDONLY|O_CLOEXEC);
+#else
+    int fd = open("/dev/urandom", O_RDONLY);
+    fcntl(fd, F_SETFD, FD_CLOEXEC);
+#endif
     if (fd != -1) {
       ssize_t n = read(fd, rs->u, sizeof(rs->u));
       (void)close(fd);


### PR DESCRIPTION
Apple added O_CLOEXEC in OSX 10.7 and iOS 4.3, I've tested this patch with iOS 3.1.3 and everything works