### PR TITLE
MIPS32: Fix little-endian IR_RETF

### DIFF
--- a/src/lj_asm_mips.h
+++ b/src/lj_asm_mips.h
@@ -456,7 +456,7 @@ static void asm_retf(ASMState *as, IRIns *ir)
   emit_addptr(as, base, -8*delta);
   asm_guard(as, MIPSI_BNE, RID_TMP,
 	    ra_allock(as, igcptr(pc), rset_exclude(RSET_GPR, base)));
-  emit_tsi(as, MIPSI_AL, RID_TMP, base, -8);
+  emit_tsi(as, MIPSI_AL, RID_TMP, base, (LJ_BE || LJ_FR2) ? -8 : -4);
 }
 
 /* -- Buffer operations --------------------------------------------------- */


### PR DESCRIPTION
The guard here would always cause a trace abort on 32-bit little-endian MIPS, as it was reading the `GCfunc*` field rather than the `BCIns*` field, and a `GCfunc*` will never equal a `BCIns*`.