### PR TITLE
ARM64: Allow LDRL for loading FP constants directly to FP registers

### DIFF
--- a/src/lj_target_arm64.h
+++ b/src/lj_target_arm64.h
@@ -281,6 +281,7 @@ typedef enum A64Ins {
   A64I_FSQRTd = 0x1e61c000,
   A64I_LDRs = 0xbd400000,
   A64I_LDRd = 0xfd400000,
+  A64I_LDRLd = 0x5c000000,
   A64I_STRs = 0xbd000000,
   A64I_STRd = 0xfd000000,
   A64I_LDPs = 0x2d400000,


### PR DESCRIPTION
This is neater than doing LDRL to RID_TMP followed by A64I_FMOV_D_R.