### PR TITLE
Consistently use IRT_NIL for IR_TBAR.

### DIFF
--- a/src/lj_ffrecord.c
+++ b/src/lj_ffrecord.c
@@ -259,7 +259,7 @@ static void LJ_FASTCALL recff_setmetatable(jit_State *J, RecordFFData *rd)
     mtref = tref_isnil(mt) ? lj_ir_knull(J, IRT_TAB) : mt;
     emitir(IRT(IR_FSTORE, IRT_TAB), fref, mtref);
     if (!tref_isnil(mt))
-      emitir(IRT(IR_TBAR, IRT_TAB), tr, 0);
+      emitir(IRT(IR_TBAR, IRT_NIL), tr, 0);
     J->base[0] = tr;
     J->needsnap = 1;
   }  /* else: Interpreter will throw. */


### PR DESCRIPTION
The IR_TBAR emitted as part of table indexing uses IRT_NIL, whereas the IR_TBAR emitted as part of setmetatable currently uses IRT_TAB. This is currently fairly harmless, but one option for addressing #1086 involves CSE actually looking at the type of instructions, at which point inconsistent types could prevent CSE. Converging on IRT_NIL is consistent with IR_OBAR.