### PR TITLE
Remove ancient RtlUnwindEx workaround

### DIFF
--- a/src/lj_err.c
+++ b/src/lj_err.c
@@ -239,12 +239,6 @@ typedef struct UndocumentedDispatcherContext {
 /* Another wild guess. */
 extern void __DestructExceptionObject(EXCEPTION_RECORD *rec, int nothrow);
 
-#if LJ_TARGET_X64 && defined(MINGW_SDK_INIT)
-/* Workaround for broken MinGW64 declaration. */
-VOID RtlUnwindEx_FIXED(PVOID,PVOID,PVOID,PVOID,PVOID,PVOID) asm("RtlUnwindEx");
-#define RtlUnwindEx RtlUnwindEx_FIXED
-#endif
-
 #define LJ_MSVC_EXCODE		((DWORD)0xe06d7363)
 #define LJ_GCC_EXCODE		((DWORD)0x20474343)
 


### PR DESCRIPTION
No longer needed since this change:
https://sourceforge.net/p/mingw-w64/mingw-w64/ci/952dce438458357a3b39d13c808a2f0122841017

Fixes "expected function body after function declarator" on LLVM toolchain, on this inline asm.