### PR TITLE
Use of MAP_JIT flag on MacOS.

### DIFF
--- a/src/lj_mcode.c
+++ b/src/lj_mcode.c
@@ -106,10 +106,14 @@ static int mcode_setprot(void *p, size_t sz, DWORD prot)
 #else
 #define MCPROT_CREATE	0
 #endif
+// MacOS mmap MAP_JIT flag
+#ifndef MAP_JIT
+#define MAP_JIT 0
+#endif
 
 static void *mcode_alloc_at(jit_State *J, uintptr_t hint, size_t sz, int prot)
 {
-  void *p = mmap((void *)hint, sz, prot|MCPROT_CREATE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+  void *p = mmap((void *)hint, sz, prot|MCPROT_CREATE, MAP_PRIVATE|MAP_ANONYMOUS|MAP_JIT, -1, 0);
   if (p == MAP_FAILED) {
     if (!hint) lj_trace_err(J, LJ_TRERR_MCODEAL);
     p = NULL;


### PR DESCRIPTION
This allows full performance in MacOS apps with entitlement [com.apple.security.cs.allow-jit](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_allow-jit) instead of less secure [com.apple.security.cs.disable-executable-page-protection](https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_cs_disable-executable-page-protection).
