### PR TITLE
Make dynasm accept labels and stmts on same line

### DIFF
--- a/dynasm/dynasm.lua
+++ b/dynasm/dynasm.lua
@@ -861,6 +861,10 @@ local function doline(line)
   -- Strip assembler comments.
   aline = gsub(aline, "//.*$", "")
 
+  -- Process and remove labels.
+  for stmt in gmatch(aline, "[^:]+:") do dostmt(stmt) end
+  aline = gsub(aline, "[^:]+:", "")
+
   -- Split line into statements at semicolons.
   if match(aline, ";") then
     for stmt in gmatch(aline, "[^;]+") do dostmt(stmt) end


### PR DESCRIPTION
Now accepts e.g.:

    1: jmp <1

Used to be a parse error.