### PR TITLE
fix(p.lua): ensure file handle is closed with zero samples

### DIFF
--- a/src/jit/p.lua
+++ b/src/jit/p.lua
@@ -227,6 +227,7 @@ local function prof_finish()
     local samples = prof_samples
     if samples == 0 then
       if prof_raw ~= true then out:write("[No samples collected]\n") end
+      if out ~= stdout then out:close() end
       return
     end
     if prof_ann then


### PR DESCRIPTION
Problem: When using p.lua profiler module, the file handle isn't closed when no samples are collected as addressed in #1304 . This issue was discovered through neovim/neovim#31091.

Solution: Add file handle closure when no samples are collected