### PR TITLE
Update Makefile

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -593,6 +593,7 @@ ifeq (static,$(BUILDMODE))
   TARGET_DYNCC= @:
   TARGET_T= $(LUAJIT_T)
   TARGET_DEP= $(LIB_VMDEF)
+  TARGET_ALDFLAGS+= -static
 else
 ifeq (dynamic,$(BUILDMODE))
   ifneq (Windows,$(TARGET_SYS))


### PR DESCRIPTION
Added 'TARGET_ALDFLAG+= -static' in case of static build.
Without this the build is going to be a "mixed" build, with dynamically linked binary.

Without -static:
```bash
> ldd src/luajit
src/luajit:
    libm.so.5 => /lib/libm.so.5 (0x1abaab1ea000)
    libgcc_s.so.1 => /lib/libgcc_s.so.1 (0x1abaac124000)
    libc.so.7 => /lib/libc.so.7 (0x1abaaca95000)
    [vdso] (0x1abaaa398000)
```
With -static:
```bash
> ldd src/luajit
ldd: src/luajit: not a dynamic ELF executable
```