### PR TITLE
Add support for Lua 5.2 compat in msvcbuild.bat

### DIFF
--- a/src/msvcbuild.bat
+++ b/src/msvcbuild.bat
@@ -5,11 +5,12 @@
 @rem Then cd to this directory and run this script. Use the following
 @rem options (in order), if needed. The default is a dynamic release build.
 @rem
-@rem   nogc64   disable LJ_GC64 mode for x64
-@rem   debug    emit debug symbols
-@rem   amalg    amalgamated build
-@rem   static   create static lib to statically link into your project
-@rem   mixed    create static lib to build a DLL in your project
+@rem   nogc64        disable LJ_GC64 mode for x64
+@rem   debug         emit debug symbols
+@rem   lua52compat   enable extra Lua 5.2 extensions
+@rem   amalg         amalgamated build
+@rem   static        create static lib to statically link into your project
+@rem   mixed         create static lib to build a DLL in your project
 
 @if not defined INCLUDE goto :FAIL
 
@@ -101,6 +102,10 @@ buildvm -m folddef -o lj_folddef.h lj_opt_fold.c
 @set LJDYNBUILD=%LJDYNBUILD_DEBUG%
 @set LJLINKTYPE=%LJLINKTYPE_DEBUG%
 :NODEBUG
+@if "%1" neq "lua52compat" goto :NOLUA52COMPAT
+@shift
+@set LJCOMPILE=%LJCOMPILE% /DLUAJIT_ENABLE_LUA52COMPAT
+:NOLUA52COMPAT
 @set LJCOMPILE=%LJCOMPILE% %LJCOMPILETARGET%
 @set LJLINK=%LJLINK% %LJLINKTYPE% %LJLINKTARGET%
 @if "%1"=="amalg" goto :AMALGDLL


### PR DESCRIPTION
This PR adds support for building LuaJIT with `/DLUAJIT_ENABLE_LUA52COMPAT` by passing `lua52compat` option to msvcbuild.bat.