### PR TITLE
arm64: Add bti_jump where vm_tobit_fb jumps in

### DIFF
--- a/src/vm_arm64.dasc
+++ b/src/vm_arm64.dasc
@@ -1696,6 +1696,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  adr lr, >1
   |  checkint CARG1, ->vm_tobit_fb
   |1:
+  |  bti_jump
   |.endmacro
   |
   |.macro .ffunc_bit_op, name, ins
@@ -1710,6 +1711,7 @@ static void build_subroutines(BuildCtx *ctx)
   |   bge >9
   |  checkint CARG1, ->vm_tobit_fb
   |2:
+  |  bti_jump
   |  ins TMP0w, TMP0w, CARG1w
   |  b <1
   |.endmacro
@@ -1742,6 +1744,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  adr lr, >1
   |  checkint CARG1, ->vm_tobit_fb
   |1:
+  |  bti_jump
   |.if shmod == 0
   |  mov TMP1, CARG1
   |.else
@@ -1751,6 +1754,7 @@ static void build_subroutines(BuildCtx *ctx)
   |  adr lr, >2
   |  checkint CARG1, ->vm_tobit_fb
   |2:
+  |  bti_jump
   |  ins TMP0w, CARG1w, TMP1w
   |  add_TISNUM CARG1, TMP0
   |  b ->fff_restv


### PR DESCRIPTION
At the end of 'vm_tobit_fb', it jumps to an address that lr register indicates. This is an indirect branch, so we need a `bti j` instruction at the address it jumps to. I see the caller of 'vm_tobit_fb' always sets the target address. I inserted the bti_jump macro in these addresses.

I confirmed all the test in https://github.com/LuaJIT/LuaJIT-test-cleanup test directory with my patch.