### PR TITLE
Ignore pdb Files in Git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 *.dmp
 *.swp
 .tags
+*.pdb


### PR DESCRIPTION
This change simply adds `*.pdb` to the `.gitignore`.  These files get generated when using the `msvcbuild.bat` with the `static` option.