### PR TITLE
Fix const warnings with glibc-2.43 strchr()

### DIFF
--- a/src/lj_clib.c
+++ b/src/lj_clib.c
@@ -81,7 +81,7 @@ static const char *clib_extname(lua_State *L, const char *name)
 /* Check for a recognized ld script line. */
 static const char *clib_check_lds(lua_State *L, const char *buf)
 {
-  char *p, *e;
+  const char *p, *e;
   if ((!strncmp(buf, "GROUP", 5) || !strncmp(buf, "INPUT", 5)) &&
       (p = strchr(buf, '('))) {
     while (*++p == ' ') ;


### PR DESCRIPTION
This may break the build depending on people's compiler settings.
Found in https://github.com/gentoo/gentoo/pull/45777
Signed-off-by: Holger Hoffstätte <holger@applied-asynchrony.com>
